### PR TITLE
chore: update module path to github.com/slashdevops/qfv

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -9,7 +9,7 @@ profile: coverage.txt
 
 # (optional; but recommended to set)
 # When specified reported file paths will not contain local prefix in the output.
-local-prefix: "github.com/p2p-b2b/qfv"
+local-prefix: "github.com/slashdevops/qfv"
 
 # Holds coverage thresholds percentages, values should be in range [0-100].
 threshold:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The library ensures that only allowed fields are used in these expressions, help
 ## Installation
 
 ```bash
-go get github.com/p2p-b2b/qfv@latest
+go get github.com/slashdevops/qfv@latest
 ```
 
 ## Usage
@@ -29,7 +29,7 @@ import (
   "fmt"
   "log"
 
-  qfv "github.com/p2p-b2b/qfv"
+  qfv "github.com/slashdevops/qfv"
 )
 
 func main() {

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	qfv "github.com/p2p-b2b/qfv"
+	qfv "github.com/slashdevops/qfv"
 )
 
 func TestParsers(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/p2p-b2b/qfv
+module github.com/slashdevops/qfv
 
 go 1.24.2


### PR DESCRIPTION
## Summary

The repository was transferred to the **slashdevops** organization (from `p2p-b2b`). This updates the Go module path and all references accordingly.

### Changes
- `go.mod`: module path → `github.com/slashdevops/qfv`
- `.testcoverage.yml`: `local-prefix` → `github.com/slashdevops/qfv`
- `README.md`: install command and import example
- `example/example_test.go`: import path

### Verification
- `go build ./...` ✅
- `go test ./...` ✅ (all packages pass)
- No remaining `p2p-b2b` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)