### PR TITLE
fix!: reject invalid filter input and make the parser correct & concurrency-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,91 @@ if err != nil {
     // err contains syntax error details
 }
 ```
+
+The filter parser aggregates every problem it finds in a single pass using
+[`errors.Join`](https://pkg.go.dev/errors#Join), so a returned error may wrap
+several `*QFVFilterError` values. Use `errors.As` to inspect them:
+
+```go
+_, err := filterParser.Parse("unknown = 'x' garbage")
+var fe *qfv.QFVFilterError
+if errors.As(err, &fe) {
+    // fe.Field / fe.Message for the first matching cause
+}
+```
+
+## Breaking Changes & Migration (v0.0.x → v0.1.0)
+
+`v0.1.0` fixes correctness bugs in the filter parser and validator. If you only
+call `Parse` and check the returned `error`, most changes are transparent — the
+parser now rejects inputs it previously accepted by mistake. If you **inspect the
+returned AST**, review the notes below.
+
+### 1. Trailing/incomplete input is now rejected (behavior change)
+
+Previously the parser stopped at the first complete expression and silently
+ignored the rest, so invalid input validated successfully. It now requires the
+**entire** input to be consumed.
+
+| Input | Before `v0.1.0` | `v0.1.0` |
+| --- | --- | --- |
+| `first_name = 'John' garbage` | ✅ accepted | ❌ error |
+| `age > 30 40` | ✅ accepted | ❌ error |
+| `first_name = 'John')` | ✅ accepted | ❌ error |
+| `1 = 1` | ✅ accepted | ❌ error |
+
+**Migration:** none required for valid queries. If you relied on the lenient
+behavior, fix the offending inputs — they were never valid.
+
+### 2. Negated operators now set `IsNot` instead of wrapping in `UnaryOperatorNode` (AST change)
+
+`NOT IN`, `NOT BETWEEN`, `NOT SIMILAR TO`, and `NOT DISTINCT FROM` previously
+produced a `UnaryOperatorNode{Operator: NOT}` wrapping the inner node (whose own
+`IsNot` was always `false`). They now return the operator node directly with
+`IsNot = true`, matching how `RegexMatchNode` already worked. `NOT LIKE` now
+produces a `BinaryOperatorNode` with `Operator = TokenOperatorNotLike` instead of
+a wrapped `TokenOperatorLike`.
+
+```go
+// Before: type-switch had to unwrap the NOT node
+if u, ok := node.(*qfv.UnaryOperatorNode); ok && u.Operator == qfv.TokenOperatorNot {
+    if in, ok := u.X.(*qfv.InNode); ok { /* negated IN */ }
+}
+
+// After: the node carries its own negation
+if in, ok := node.(*qfv.InNode); ok && in.IsNot { /* negated IN */ }
+```
+
+The `IsNot` fields on `InNode`, `BetweenNode`, `SimilarToNode`, and `DistinctNode`
+are now meaningful, and `Type()` returns the corresponding `NodeTypeNotIn`,
+`NodeTypeNotBetween`, `NodeTypeNotSimilarTo`, or `NodeTypeNotDistinct`. The
+`String()` methods now render the `NOT`/`IS NOT` form correctly.
+
+> Note: a standalone leading `NOT` (e.g. `NOT (age > 30)`) is unchanged — it
+> still produces a `UnaryOperatorNode`.
+
+### 3. `DistinctNode` gained a `Value` field (AST change)
+
+`DISTINCT FROM <value>` previously discarded the compared value. `DistinctNode`
+now has a `Value Node` field holding it (`nil` when absent).
+
+```go
+type DistinctNode struct {
+    Field Node
+    Value Node // NEW: the value in "field IS [NOT] DISTINCT FROM value"
+    IsNot bool
+}
+```
+
+### 4. `Parse` returns a joined error, not a single formatted string (error shape change)
+
+`FilterParser.Parse` now returns `errors.Join(...)` of `*QFVFilterError` values
+rather than one `*QFVFilterError` whose message embedded the others. Use
+`errors.As`/`errors.Is` to inspect causes (see [Error Handling](#error-handling)).
+Code that only checked `err != nil` is unaffected.
+
+### 5. `FilterParser` is now safe for concurrent use
+
+A single `*FilterParser` (like `*SortParser` and `*FieldsParser`) can now be
+created once and shared across goroutines; per-request state is no longer stored
+on the parser. No API change — this simply removes a data race.

--- a/fields_parser.go
+++ b/fields_parser.go
@@ -29,12 +29,12 @@ func (n FieldsNode) Type() NodeType {
 
 // FieldsParser parses the query parameter for fields
 type FieldsParser struct {
-	allowedFieldsFields map[string]any // any because don't allocate memory for struct{}
+	allowedFieldsFields map[string]struct{}
 }
 
 // NewFieldsParser creates a new parser with the allowed fields
 func NewFieldsParser(allowedFields []string) *FieldsParser {
-	fieldsFields := make(map[string]any, len(allowedFields))
+	fieldsFields := make(map[string]struct{}, len(allowedFields))
 
 	for _, f := range allowedFields {
 		fieldsFields[f] = struct{}{}

--- a/filter_lexer.go
+++ b/filter_lexer.go
@@ -132,7 +132,6 @@ func (l *Lexer) Parse() {
 			tok = TokenComma
 		case '=':
 			tok = TokenOperatorEqual
-		case '+':
 		case '<':
 			if l.s.Peek() == '=' {
 				l.s.Scan()

--- a/filter_nodes.go
+++ b/filter_nodes.go
@@ -42,8 +42,16 @@ type SimilarToNode struct {
 	IsNot   bool // true for NOT SIMILAR TO
 }
 
-func (n *SimilarToNode) Type() NodeType { return NodeTypeSimilarTo }
+func (n *SimilarToNode) Type() NodeType {
+	if n.IsNot {
+		return NodeTypeNotSimilarTo
+	}
+	return NodeTypeSimilarTo
+}
 func (n *SimilarToNode) String() string {
+	if n.IsNot {
+		return fmt.Sprintf("%s NOT SIMILAR TO %s", n.Field.String(), n.Pattern.String())
+	}
 	return fmt.Sprintf("%s SIMILAR TO %s", n.Field.String(), n.Pattern.String())
 }
 func (n *SimilarToNode) Pos() scanner.Position { return n.pos }
@@ -167,8 +175,18 @@ type IsNullNode struct {
 	IsNot bool // true for IS NOT NULL
 }
 
-func (n *IsNullNode) Type() NodeType        { return NodeTypeIsNull }
-func (n *IsNullNode) String() string        { return fmt.Sprintf("%s IS NULL", n.Field.String()) }
+func (n *IsNullNode) Type() NodeType {
+	if n.IsNot {
+		return NodeTypeIsNotNull
+	}
+	return NodeTypeIsNull
+}
+func (n *IsNullNode) String() string {
+	if n.IsNot {
+		return fmt.Sprintf("%s IS NOT NULL", n.Field.String())
+	}
+	return fmt.Sprintf("%s IS NULL", n.Field.String())
+}
 func (n *IsNullNode) Pos() scanner.Position { return n.pos }
 
 // InNode represents an IN expression (e.g., name IN ("John", "Doe"))
@@ -179,26 +197,50 @@ type InNode struct {
 	Values []Node
 }
 
-func (n *InNode) Type() NodeType { return NodeTypeIn }
+func (n *InNode) Type() NodeType {
+	if n.IsNot {
+		return NodeTypeNotIn
+	}
+	return NodeTypeIn
+}
 func (n *InNode) String() string {
 	var values []string
 	for _, v := range n.Values {
 		values = append(values, v.String())
 	}
 
-	return fmt.Sprintf("%s IN (%s)", n.Field.String(), strings.Join(values, ", "))
+	op := "IN"
+	if n.IsNot {
+		op = "NOT IN"
+	}
+	return fmt.Sprintf("%s %s (%s)", n.Field.String(), op, strings.Join(values, ", "))
 }
 func (n *InNode) Pos() scanner.Position { return n.pos }
 
-// DistinctNode represents a DISTINCT expression (e.g., name DISTINCT)
+// DistinctNode represents a DISTINCT FROM expression (e.g., name DISTINCT FROM 'John')
 type DistinctNode struct {
 	baseNode
 	Field Node
-	IsNot bool // true for NOT DISTINCT
+	Value Node // the value being compared against; nil when absent
+	IsNot bool // true for NOT DISTINCT FROM
 }
 
-func (n *DistinctNode) Type() NodeType        { return NodeTypeDistinct }
-func (n *DistinctNode) String() string        { return fmt.Sprintf("%s DISTINCT", n.Field.String()) }
+func (n *DistinctNode) Type() NodeType {
+	if n.IsNot {
+		return NodeTypeNotDistinct
+	}
+	return NodeTypeDistinct
+}
+func (n *DistinctNode) String() string {
+	op := "DISTINCT"
+	if n.IsNot {
+		op = "NOT DISTINCT"
+	}
+	if n.Value != nil {
+		return fmt.Sprintf("%s %s FROM %s", n.Field.String(), op, n.Value.String())
+	}
+	return fmt.Sprintf("%s %s", n.Field.String(), op)
+}
 func (n *DistinctNode) Pos() scanner.Position { return n.pos }
 
 // BetweenNode represents a BETWEEN expression (e.g., age BETWEEN 30 AND 40)
@@ -210,8 +252,17 @@ type BetweenNode struct {
 	IsNot bool // true for NOT BETWEEN
 }
 
-func (n *BetweenNode) Type() NodeType { return NodeTypeBetween }
+func (n *BetweenNode) Type() NodeType {
+	if n.IsNot {
+		return NodeTypeNotBetween
+	}
+	return NodeTypeBetween
+}
 func (n *BetweenNode) String() string {
-	return fmt.Sprintf("%s BETWEEN %s AND %s", n.Field.String(), n.Lower.String(), n.Upper.String())
+	op := "BETWEEN"
+	if n.IsNot {
+		op = "NOT BETWEEN"
+	}
+	return fmt.Sprintf("%s %s %s AND %s", n.Field.String(), op, n.Lower.String(), n.Upper.String())
 }
 func (n *BetweenNode) Pos() scanner.Position { return n.pos }

--- a/filter_parser.go
+++ b/filter_parser.go
@@ -1,6 +1,7 @@
 package qfv
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -21,17 +22,18 @@ func (e *QFVFilterError) Error() string {
 	return fmt.Sprintf("error: %s", e.Message)
 }
 
-// FilterParser parses the query parameter for filtering
+// FilterParser parses the query parameter for filtering.
+//
+// A FilterParser holds only the immutable set of allowed fields, so a single
+// instance is safe for concurrent use by multiple goroutines: the mutable
+// state required to parse one expression lives in a per-call filterParseState.
 type FilterParser struct {
-	allowedFields map[string]any // any because don't allocate memory for struct{}
-	lexer         *Lexer
-	currentToken  Token
-	errors        []error
+	allowedFields map[string]struct{}
 }
 
 // NewFilterParser creates a new parser with the allowed fields
 func NewFilterParser(allowedFields []string) *FilterParser {
-	filterFields := make(map[string]any, len(allowedFields))
+	filterFields := make(map[string]struct{}, len(allowedFields))
 
 	for _, f := range allowedFields {
 		filterFields[f] = struct{}{}
@@ -42,41 +44,59 @@ func NewFilterParser(allowedFields []string) *FilterParser {
 	}
 }
 
+// filterParseState holds the mutable state for a single Parse call. Keeping it
+// out of FilterParser is what makes FilterParser safe for concurrent reuse.
+type filterParseState struct {
+	allowedFields map[string]struct{}
+	lexer         *Lexer
+	currentToken  Token
+	errors        []error
+}
+
 // Parse parses the filter query and returns the AST
 func (p *FilterParser) Parse(input string) (Node, error) {
-	p.lexer = NewLexer(input)
-	p.lexer.Parse()
-	p.errors = nil
+	st := &filterParseState{
+		allowedFields: p.allowedFields,
+		lexer:         NewLexer(input),
+	}
+	st.lexer.Parse()
 
 	// Check for illegal tokens in the input
-	for _, token := range p.lexer.tokens {
+	for _, token := range st.lexer.tokens {
 		if token.Type == TokenIllegal {
-			p.addError(&QFVFilterError{Field: token.Value, Message: "illegal token"})
+			st.addError(&QFVFilterError{Field: token.Value, Message: "illegal token"})
 		}
 	}
 
-	p.nextToken()
+	st.nextToken()
 
-	if p.currentToken.Type == TokenEOF {
+	if st.currentToken.Type == TokenEOF {
 		return nil, &QFVFilterError{Message: "empty filter expression"}
 	}
 
-	node := p.parseExpression()
+	node := st.parseExpression()
 
-	if len(p.errors) > 0 {
-		return nil, &QFVFilterError{Message: fmt.Sprintf("parsing errors: %v", p.errors)}
+	// The whole input must be consumed. Any leftover tokens mean only a prefix
+	// of the input was a valid expression (e.g. "name = 'John' garbage"), which
+	// must be reported instead of silently accepted.
+	if st.currentToken.Type != TokenEOF {
+		st.addError(&QFVFilterError{Message: fmt.Sprintf("unexpected token %q after a complete expression", st.currentToken.Value)})
+	}
+
+	if len(st.errors) > 0 {
+		return nil, errors.Join(st.errors...)
 	}
 
 	return node, nil
 }
 
 // nextToken advances to the next token
-func (p *FilterParser) nextToken() {
+func (p *filterParseState) nextToken() {
 	p.currentToken = p.lexer.Next()
 }
 
 // expect checks if the current token is of the expected type
-func (p *FilterParser) expect(tokenType TokenType) bool {
+func (p *filterParseState) expect(tokenType TokenType) bool {
 	if p.currentToken.Type == tokenType {
 		p.nextToken()
 		return true
@@ -87,17 +107,17 @@ func (p *FilterParser) expect(tokenType TokenType) bool {
 }
 
 // addError adds an error to the error list
-func (p *FilterParser) addError(err error) {
+func (p *filterParseState) addError(err error) {
 	p.errors = append(p.errors, err)
 }
 
 // parseExpression parses an expression
-func (p *FilterParser) parseExpression() Node {
+func (p *filterParseState) parseExpression() Node {
 	return p.parseLogicalOr()
 }
 
 // parseLogicalOr parses OR expressions
-func (p *FilterParser) parseLogicalOr() Node {
+func (p *filterParseState) parseLogicalOr() Node {
 	left := p.parseLogicalAnd()
 
 	for p.currentToken.Type == TokenOperatorOr {
@@ -117,7 +137,7 @@ func (p *FilterParser) parseLogicalOr() Node {
 }
 
 // parseLogicalAnd parses AND expressions
-func (p *FilterParser) parseLogicalAnd() Node {
+func (p *filterParseState) parseLogicalAnd() Node {
 	left := p.parseComparison()
 
 	for p.currentToken.Type == TokenOperatorAnd {
@@ -137,7 +157,7 @@ func (p *FilterParser) parseLogicalAnd() Node {
 }
 
 // parseComparison parses comparison expressions
-func (p *FilterParser) parseComparison() Node {
+func (p *filterParseState) parseComparison() Node {
 	// Check for NOT operator
 	if p.currentToken.Type == TokenOperatorNot {
 		pos := p.currentToken.Pos
@@ -185,22 +205,22 @@ func (p *FilterParser) parseComparison() Node {
 			return p.parseComparisonOperator(field)
 		case TokenOperatorLike:
 			p.nextToken() // Consume LIKE
-			return p.parseLikeOperator(field)
+			return p.parseLikeOperator(field, false)
 		case TokenOperatorIn:
 			p.nextToken() // Consume IN
-			return p.parseInOperator(field)
+			return p.parseInOperator(field, false)
 		case TokenOperatorBetween:
 			p.nextToken() // Consume BETWEEN
-			return p.parseBetweenOperator(field)
+			return p.parseBetweenOperator(field, false)
 		case TokenOperatorIsNull:
 			p.nextToken() // Consume IS
 			return p.parseIsNullOperator(field)
 		case TokenOperatorDistinct:
 			p.nextToken() // Consume DISTINCT
-			return p.parseDistinctOperator(field)
+			return p.parseDistinctOperator(field, false)
 		case TokenOperatorSimilarTo:
 			p.nextToken() // Consume SIMILAR
-			return p.parseSimilarToOperator(field)
+			return p.parseSimilarToOperator(field, false)
 		case TokenOperatorRegexMatchCS, TokenOperatorNotRegexMatchCS, TokenOperatorRegexMatchCI, TokenOperatorNotRegexMatchCI:
 			opToken := p.currentToken
 			p.nextToken() // Consume regex operator
@@ -223,69 +243,32 @@ func (p *FilterParser) parseComparison() Node {
 				IsCaseInsensitive: opToken.Type == TokenOperatorRegexMatchCI || opToken.Type == TokenOperatorNotRegexMatchCI,
 			}
 		case TokenOperatorNot:
-			// Handle NOT operators (NOT IN, NOT BETWEEN, NOT LIKE, NOT SIMILAR TO, IS NOT NULL, NOT DISTINCT FROM)
-			notPos := p.currentToken.Pos
+			// Handle NOT operators (NOT IN, NOT BETWEEN, NOT LIKE, NOT SIMILAR TO,
+			// NOT DISTINCT FROM). Negation is recorded on the resulting node via its
+			// IsNot flag (or the NOT LIKE operator), not by wrapping in a NOT node,
+			// so that consumers get a single, self-describing node.
 			p.nextToken() // Consume NOT
 
-			var notExpr Node
 			switch p.currentToken.Type {
 			case TokenOperatorIn:
 				p.nextToken() // Consume IN
-				notExpr = p.parseInOperator(field)
+				return p.parseInOperator(field, true)
 			case TokenOperatorBetween:
 				p.nextToken() // Consume BETWEEN
-				notExpr = p.parseBetweenOperator(field)
+				return p.parseBetweenOperator(field, true)
 			case TokenOperatorLike:
 				p.nextToken() // Consume LIKE
-				notExpr = p.parseLikeOperator(field)
+				return p.parseLikeOperator(field, true)
 			case TokenOperatorSimilarTo:
-				p.nextToken()                             // Consume SIMILAR
-				notExpr = p.parseSimilarToOperator(field) // Expects TO next
-			case TokenOperatorIsNull: // Handle IS NOT NULL here
-				p.nextToken() // Consume IS
-				// parseIsNullOperator handles the NOT internally now based on token sequence
-				notExpr = p.parseIsNullOperator(field)
-				// Check if parseIsNullOperator correctly identified IS NOT NULL
-				if isNullNode, ok := notExpr.(*IsNullNode); !ok || !isNullNode.IsNot {
-					// If parseIsNullOperator didn't return an IsNullNode with IsNot=true,
-					// it means the sequence wasn't "IS NOT NULL".
-					// The error would have been added inside parseIsNullOperator.
-					// We might return the field or a generic error node, but returning
-					// the result from parseIsNullOperator (which might be 'field') is consistent.
-					return notExpr // Return whatever parseIsNullOperator returned on error
-				}
-				// If it was IS NOT NULL, we don't need to wrap it again
-				return notExpr
-			case TokenOperatorDistinct: // Handle NOT DISTINCT FROM here
+				p.nextToken() // Consume SIMILAR
+				return p.parseSimilarToOperator(field, true)
+			case TokenOperatorDistinct:
 				p.nextToken() // Consume DISTINCT
-				// parseDistinctOperator handles the FROM internally
-				notExpr = p.parseDistinctOperator(field)
-				// Similar to IS NOT NULL, check if parseDistinctOperator failed
-				if _, ok := notExpr.(*DistinctNode); !ok {
-					return notExpr // Return error node or field
-				}
+				return p.parseDistinctOperator(field, true)
 			default:
 				p.addError(&QFVFilterError{Message: fmt.Sprintf("unexpected token after NOT: %s", p.currentToken.Type)})
-				// If NOT is followed by something unexpected, return a unary NOT node with the field
-				// This might not be the most robust error handling, but fits the previous pattern.
-				return &UnaryOperatorNode{
-					baseNode: baseNode{pos: notPos},
-					Operator: TokenOperatorNot,
-					X:        field, // Apply NOT to the field itself? Or error?
-				}
+				return field
 			}
-
-			// Wrap the parsed expression (LIKE, IN, BETWEEN, SIMILAR TO, DISTINCT) in a UnaryOperatorNode(NOT)
-			// Skip wrapping if it was handled internally (IS NOT NULL)
-			if _, isIsNull := notExpr.(*IsNullNode); !isIsNull {
-				return &UnaryOperatorNode{
-					baseNode: baseNode{pos: notPos},
-					Operator: TokenOperatorNot,
-					X:        notExpr,
-				}
-			}
-			// For IS NOT NULL, return the node directly as IsNot is set inside
-			return notExpr
 
 		default:
 			p.addError(&QFVFilterError{Field: field.Name, Message: "unexpected token after field"})
@@ -298,7 +281,7 @@ func (p *FilterParser) parseComparison() Node {
 }
 
 // parseComparisonOperator parses comparison operators (=, <>, !=, <, <=, >, >=)
-func (p *FilterParser) parseComparisonOperator(field Node) Node {
+func (p *filterParseState) parseComparisonOperator(field Node) Node {
 	pos := p.currentToken.Pos
 	operator := p.currentToken.Type
 	p.nextToken()
@@ -313,7 +296,7 @@ func (p *FilterParser) parseComparisonOperator(field Node) Node {
 
 // parseSimilarToOperator parses SIMILAR TO operator
 // Expects the current token to be TO after SIMILAR was consumed.
-func (p *FilterParser) parseSimilarToOperator(field Node) Node {
+func (p *filterParseState) parseSimilarToOperator(field Node, isNot bool) Node {
 	pos := p.lexer.Current().Pos // Use position of SIMILAR token (already consumed)
 	if p.currentToken.Type != TokenIdentifier || strings.ToUpper(p.currentToken.Value) != "TO" {
 		p.addError(&QFVFilterError{Message: "expected TO after SIMILAR"})
@@ -325,26 +308,30 @@ func (p *FilterParser) parseSimilarToOperator(field Node) Node {
 		baseNode: baseNode{pos: pos},
 		Field:    field,
 		Pattern:  pattern,
-		IsNot:    false, // NOT is handled by parseComparison
+		IsNot:    isNot,
 	}
 }
 
 // parseLikeOperator parses LIKE operator
 // Expects the current token to be the pattern after LIKE was consumed.
-func (p *FilterParser) parseLikeOperator(field Node) Node {
+func (p *filterParseState) parseLikeOperator(field Node, isNot bool) Node {
 	pos := p.lexer.Current().Pos // Use position of LIKE token (already consumed)
 	pattern := p.parsePrimary()
+	operator := TokenOperatorLike
+	if isNot {
+		operator = TokenOperatorNotLike
+	}
 	return &BinaryOperatorNode{
 		baseNode: baseNode{pos: pos},
 		Left:     field,
 		Right:    pattern,
-		Operator: TokenOperatorLike,
+		Operator: operator,
 	}
 }
 
 // parseInOperator parses IN operator
 // Expects the current token to be LPAREN after IN was consumed.
-func (p *FilterParser) parseInOperator(field Node) Node {
+func (p *filterParseState) parseInOperator(field Node, isNot bool) Node {
 	pos := p.lexer.Current().Pos // Use position of IN token (already consumed)
 	if !p.expect(TokenLPAREN) {
 		p.addError(&QFVFilterError{Message: "expected opening parenthesis after IN"})
@@ -376,14 +363,14 @@ func (p *FilterParser) parseInOperator(field Node) Node {
 	return &InNode{
 		baseNode: baseNode{pos: pos},
 		Field:    field,
-		IsNot:    false, // NOT is handled by parseComparison
+		IsNot:    isNot,
 		Values:   values,
 	}
 }
 
 // parseBetweenOperator parses BETWEEN operator
 // Expects the current token to be the lower bound after BETWEEN was consumed.
-func (p *FilterParser) parseBetweenOperator(field Node) Node {
+func (p *filterParseState) parseBetweenOperator(field Node, isNot bool) Node {
 	pos := p.lexer.Current().Pos // Use position of BETWEEN token (already consumed)
 	lower := p.parsePrimary()
 
@@ -399,13 +386,13 @@ func (p *FilterParser) parseBetweenOperator(field Node) Node {
 		Field:    field,
 		Lower:    lower,
 		Upper:    upper,
-		IsNot:    false, // NOT is handled by parseComparison
+		IsNot:    isNot,
 	}
 }
 
 // parseIsNullOperator parses IS [NOT] NULL operator
 // Expects the current token to be NOT or NULL after IS was consumed.
-func (p *FilterParser) parseIsNullOperator(field Node) Node {
+func (p *filterParseState) parseIsNullOperator(field Node) Node {
 	pos := p.lexer.Current().Pos // Use position of IS token (already consumed)
 	isNot := false
 	if p.currentToken.Type == TokenOperatorNot {
@@ -433,7 +420,7 @@ func (p *FilterParser) parseIsNullOperator(field Node) Node {
 
 // parseDistinctOperator parses DISTINCT FROM operator
 // Expects the current token to be FROM after DISTINCT was consumed.
-func (p *FilterParser) parseDistinctOperator(field Node) Node {
+func (p *filterParseState) parseDistinctOperator(field Node, isNot bool) Node {
 	pos := p.lexer.Current().Pos // Use position of DISTINCT token (already consumed)
 	// Expect FROM (treated as identifier by lexer)
 	if p.currentToken.Type != TokenIdentifier || strings.ToUpper(p.currentToken.Value) != "FROM" {
@@ -441,22 +428,20 @@ func (p *FilterParser) parseDistinctOperator(field Node) Node {
 		return field // Return field on error
 	}
 	p.nextToken() // Consume FROM
-	// Parse the value being compared
-	_ = p.parsePrimary() // Consume the value but ignore it for now
+	// Parse the value being compared against and keep it on the node so callers
+	// can evaluate "field IS [NOT] DISTINCT FROM value".
+	value := p.parsePrimary()
 
-	// Note: The DistinctNode currently only holds the field and IsNot.
-	// We might need to adjust the AST node or create a new one if
-	// the `FROM value` part is significant for evaluation.
-	// For now, just return a basic DistinctNode.
 	return &DistinctNode{
 		baseNode: baseNode{pos: pos},
 		Field:    field,
-		IsNot:    false, // NOT is handled by parseComparison
+		Value:    value,
+		IsNot:    isNot,
 	}
 }
 
 // parsePrimary parses primary expressions (literals)
-func (p *FilterParser) parsePrimary() Node {
+func (p *filterParseState) parsePrimary() Node {
 	switch p.currentToken.Type {
 	case TokenString:
 		node := &LiteralNode{

--- a/filter_parser_regression_test.go
+++ b/filter_parser_regression_test.go
@@ -1,0 +1,108 @@
+package qfv
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestFilterParser_RejectsTrailingTokens ensures the parser no longer silently
+// accepts input where only a prefix forms a valid expression.
+func TestFilterParser_RejectsTrailingTokens(t *testing.T) {
+	allowed := []string{"first_name", "age"}
+	cases := []string{
+		"first_name = 'John' garbage trailing",
+		"age > 30 40",
+		"first_name = 'John' 'Doe'",
+		"first_name = 'John')",
+		"1 = 1", // literal on the left drops the operator; must not be accepted
+	}
+
+	p := NewFilterParser(allowed)
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if _, err := p.Parse(in); err == nil {
+				t.Errorf("Parse(%q) = nil error, want error for trailing/invalid tokens", in)
+			}
+		})
+	}
+}
+
+// TestFilterParser_DistinctPreservesValue ensures DISTINCT FROM keeps the
+// compared value and records negation on the node.
+func TestFilterParser_DistinctPreservesValue(t *testing.T) {
+	p := NewFilterParser([]string{"name"})
+
+	node, err := p.Parse("name IS NOT NULL AND name NOT DISTINCT FROM 'John'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_ = node // structure is covered in filter_parser_test.go; here we just want no error
+
+	n, err := p.Parse("name DISTINCT FROM 'John'")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	d, ok := n.(*DistinctNode)
+	if !ok {
+		t.Fatalf("expected *DistinctNode, got %T", n)
+	}
+	if d.IsNot {
+		t.Errorf("expected IsNot=false")
+	}
+	if d.Value == nil {
+		t.Fatal("expected DISTINCT FROM value to be preserved, got nil")
+	}
+	if got, want := d.String(), "name DISTINCT FROM 'John'"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+// TestFilterParser_ConcurrentReuse ensures a single parser instance is safe for
+// concurrent use. Run with -race to catch data races.
+func TestFilterParser_ConcurrentReuse(t *testing.T) {
+	p := NewFilterParser([]string{"a", "b"})
+	inputs := []string{
+		"a = 'x' AND b = 'y'",
+		"a IN ('x', 'y') OR b NOT BETWEEN 1 AND 5",
+		"NOT (a = 'z') AND b IS NOT NULL",
+	}
+
+	var wg sync.WaitGroup
+	for i := range 16 {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for j := range 200 {
+				if _, err := p.Parse(inputs[(seed+j)%len(inputs)]); err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestLexer_PlusIsIllegal ensures a stray '+' is flagged as an illegal token
+// instead of producing a token with an empty type.
+func TestLexer_PlusIsIllegal(t *testing.T) {
+	l := NewLexer("a + b")
+	l.Parse()
+
+	found := false
+	for _, tok := range l.tokens {
+		if tok.Value == "+" {
+			found = true
+			if tok.Type != TokenIllegal {
+				t.Errorf("'+' token type = %q, want %q", tok.Type, TokenIllegal)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("'+' token not produced by lexer")
+	}
+
+	if _, err := NewFilterParser([]string{"a", "b"}).Parse("a + b"); err == nil {
+		t.Error("Parse(\"a + b\") = nil error, want error for illegal '+' token")
+	}
+}

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -200,20 +200,12 @@ func TestFilterParser_Parse(t *testing.T) {
 			allowedFields: []string{"name", "age", "status"},
 			wantErr:       false,
 			checkNode: func(t *testing.T, node Node) {
-				unaryOp, ok := node.(*UnaryOperatorNode)
+				inExpr, ok := node.(*InNode)
 				if !ok {
-					t.Fatalf("expected UnaryOperatorNode, got %T", node)
+					t.Fatalf("expected InNode, got %T", node)
 				}
-				if unaryOp.Operator != TokenOperatorNot {
-					t.Errorf("expected NOT operator, got %s", unaryOp.Operator)
-				}
-
-				inExpr, ok := unaryOp.X.(*InNode)
-				if !ok {
-					t.Fatalf("expected InNode for NOT operand, got %T", unaryOp.X)
-				}
-				if inExpr.IsNot { // The inner InNode should have IsNot=false
-					t.Errorf("expected IsNot to be false in the InNode")
+				if !inExpr.IsNot {
+					t.Errorf("expected IsNot to be true in the InNode")
 				}
 				if len(inExpr.Values) != 2 {
 					t.Fatalf("expected 2 values in NOT IN, got %d", len(inExpr.Values))
@@ -265,20 +257,12 @@ func TestFilterParser_Parse(t *testing.T) {
 			allowedFields: []string{"name", "age", "status"},
 			wantErr:       false,
 			checkNode: func(t *testing.T, node Node) {
-				unaryOp, ok := node.(*UnaryOperatorNode)
+				betweenExpr, ok := node.(*BetweenNode)
 				if !ok {
-					t.Fatalf("expected UnaryOperatorNode, got %T", node)
+					t.Fatalf("expected BetweenNode, got %T", node)
 				}
-				if unaryOp.Operator != TokenOperatorNot {
-					t.Errorf("expected NOT operator, got %s", unaryOp.Operator)
-				}
-
-				betweenExpr, ok := unaryOp.X.(*BetweenNode)
-				if !ok {
-					t.Fatalf("expected BetweenNode for NOT operand, got %T", unaryOp.X)
-				}
-				if betweenExpr.IsNot { // The inner BetweenNode should have IsNot=false
-					t.Errorf("expected IsNot to be false in the BetweenNode")
+				if !betweenExpr.IsNot {
+					t.Errorf("expected IsNot to be true in the BetweenNode")
 				}
 			},
 		},
@@ -319,20 +303,12 @@ func TestFilterParser_Parse(t *testing.T) {
 			allowedFields: []string{"name", "age", "status"},
 			wantErr:       false,
 			checkNode: func(t *testing.T, node Node) {
-				unaryOp, ok := node.(*UnaryOperatorNode)
+				likeExpr, ok := node.(*BinaryOperatorNode)
 				if !ok {
-					t.Fatalf("expected UnaryOperatorNode, got %T", node)
+					t.Fatalf("expected BinaryOperatorNode, got %T", node)
 				}
-				if unaryOp.Operator != TokenOperatorNot {
-					t.Errorf("expected NOT operator, got %s", unaryOp.Operator)
-				}
-
-				likeExpr, ok := unaryOp.X.(*BinaryOperatorNode)
-				if !ok {
-					t.Fatalf("expected BinaryOperatorNode for NOT operand, got %T", unaryOp.X)
-				}
-				if likeExpr.Operator != TokenOperatorLike { // Check the inner node is LIKE
-					t.Errorf("expected LIKE operator in the inner node, got %s", likeExpr.Operator)
+				if likeExpr.Operator != TokenOperatorNotLike {
+					t.Errorf("expected NOT LIKE operator, got %s", likeExpr.Operator)
 				}
 			},
 		},
@@ -460,22 +436,13 @@ func TestFilterParser_Parse(t *testing.T) {
 			allowedFields: []string{"name", "age", "status"},
 			wantErr:       false,
 			checkNode: func(t *testing.T, node Node) {
-				unaryOp, ok := node.(*UnaryOperatorNode)
+				similarToExpr, ok := node.(*SimilarToNode)
 				if !ok {
-					t.Fatalf("expected UnaryOperatorNode, got %T", node)
+					t.Fatalf("expected SimilarToNode, got %T", node)
 				}
-				if unaryOp.Operator != TokenOperatorNot {
-					t.Errorf("expected NOT operator, got %s", unaryOp.Operator)
+				if !similarToExpr.IsNot {
+					t.Errorf("expected IsNot to be true in the SimilarToNode")
 				}
-
-				similarToExpr, ok := unaryOp.X.(*SimilarToNode)
-				if !ok {
-					t.Fatalf("expected SimilarToNode for NOT operand, got %T", unaryOp.X)
-				}
-				if similarToExpr.IsNot { // The inner SimilarToNode should have IsNot=false
-					t.Errorf("expected IsNot to be false in the SimilarToNode")
-				}
-				// Add checks for field/pattern if needed
 			},
 		},
 		{
@@ -499,16 +466,12 @@ func TestFilterParser_Parse(t *testing.T) {
 			allowedFields: []string{"name"},
 			wantErr:       false,
 			checkNode: func(t *testing.T, node Node) {
-				unaryOp, ok := node.(*UnaryOperatorNode)
+				similarToExpr, ok := node.(*SimilarToNode)
 				if !ok {
-					t.Fatalf("expected UnaryOperatorNode, got %T", node)
+					t.Fatalf("expected SimilarToNode, got %T", node)
 				}
-				if unaryOp.Operator != TokenOperatorNot {
-					t.Errorf("expected NOT operator")
-				}
-				_, ok = unaryOp.X.(*SimilarToNode)
-				if !ok {
-					t.Fatalf("expected SimilarToNode for NOT operand, got %T", unaryOp.X)
+				if !similarToExpr.IsNot {
+					t.Errorf("expected IsNot to be true in the SimilarToNode")
 				}
 			},
 		},
@@ -534,21 +497,21 @@ func TestFilterParser_Parse(t *testing.T) {
 			name:          "NOT DISTINCT FROM operator",
 			input:         "name NOT DISTINCT FROM 'John'",
 			allowedFields: []string{"name"},
-			wantErr:       false, // Assuming parser handles this now
+			wantErr:       false,
 			checkNode: func(t *testing.T, node Node) {
-				unaryOp, ok := node.(*UnaryOperatorNode)
+				distinctExpr, ok := node.(*DistinctNode)
 				if !ok {
-					t.Fatalf("expected UnaryOperatorNode, got %T", node)
+					t.Fatalf("expected DistinctNode, got %T", node)
 				}
-				if unaryOp.Operator != TokenOperatorNot {
-					t.Errorf("expected NOT operator")
+				if !distinctExpr.IsNot {
+					t.Errorf("expected IsNot to be true in DistinctNode")
 				}
-				distinctExpr, ok := unaryOp.X.(*DistinctNode)
+				value, ok := distinctExpr.Value.(*LiteralNode)
 				if !ok {
-					t.Fatalf("expected DistinctNode for NOT operand, got %T", unaryOp.X)
+					t.Fatalf("expected LiteralNode for value, got %T", distinctExpr.Value)
 				}
-				if distinctExpr.IsNot {
-					t.Errorf("expected IsNot to be false in DistinctNode")
+				if value.Value != "John" {
+					t.Errorf("expected value 'John', got %v", value.Value)
 				}
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/slashdevops/qfv
 
-go 1.24.2
+go 1.25.0

--- a/sort_parser.go
+++ b/sort_parser.go
@@ -51,12 +51,12 @@ func (n SortNode) Type() NodeType {
 
 // SortParser parses the query parameter for sorting
 type SortParser struct {
-	allowedFields map[string]any // any because don't allocate memory for struct{}
+	allowedFields map[string]struct{}
 }
 
 // NewSortParser creates a new parser with the allowed fields for sorting
 func NewSortParser(allowedFields []string) *SortParser {
-	sortFields := make(map[string]any, len(allowedFields))
+	sortFields := make(map[string]struct{}, len(allowedFields))
 
 	for _, f := range allowedFields {
 		sortFields[f] = struct{}{}


### PR DESCRIPTION
## Summary

The filter parser was accepting several classes of **invalid input** and producing a **misleading AST**, which undermines its role as a query *validator*. This PR fixes the core correctness bugs, removes a data race, and modernizes a few idioms. All findings were reproduced with tests before fixing.

## Bugs fixed

1. **Trailing / incomplete input silently accepted.** `Parse` stopped at the first complete expression and ignored the rest. `Parse` now requires the entire input to be consumed.

   | Input | Before | After |
   | --- | --- | --- |
   | `first_name = 'John' garbage` | ✅ accepted | ❌ error |
   | `age > 30 40` | ✅ accepted | ❌ error |
   | `first_name = 'John')` | ✅ accepted | ❌ error |
   | `1 = 1` | ✅ accepted | ❌ error |

2. **`FilterParser` was not safe for concurrent use** — confirmed data race under `go test -race`. Per-parse state (`lexer`, `currentToken`, `errors`) moved off the shared struct into a per-call `filterParseState`. `SortParser`/`FieldsParser` were already stateless; now all three can be created once and shared.

3. **Dead `IsNot` fields → misleading AST.** `NOT IN` / `NOT BETWEEN` / `NOT SIMILAR TO` / `NOT DISTINCT FROM` were wrapped in a `UnaryOperatorNode{NOT}` around a node whose own `IsNot` was always `false`. They now set `IsNot = true` on the operator node itself (consistent with how `RegexMatchNode` already worked); `NOT LIKE` uses `TokenOperatorNotLike`. `Type()` and `String()` now honor negation.

4. **`DISTINCT FROM <value>` discarded the value.** Added `DistinctNode.Value`, which now holds the compared value.

5. **Stray `+` lexed to an empty-type token** that slipped past the illegal-token check. It now lexes to `ILLEGAL`.

## Idiom / modernization

- `map[string]struct{}` sets instead of `map[string]any` (the previous "avoid allocating" comment was backwards) across all three parsers.
- `FilterParser.Parse` returns `errors.Join(...)` of `*QFVFilterError` so callers can use `errors.As`/`errors.Is`.
- `go` directive bumped to `1.25.0` (already pending in the working tree); `range`-over-int in new tests.

## Tests

- New `filter_parser_regression_test.go`: trailing tokens, DISTINCT value retention, **concurrent reuse (run under `-race`)**, and `+` lexing.
- Existing AST tests updated to assert the new negation representation.
- `go test -race ./...` green; `go vet` clean; `gofmt` clean; coverage 80.1%.

## ⚠️ Breaking changes

This is a pre-1.0 breaking change (suggested tag: **`v0.1.0`**). Full migration guide is in the README under **"Breaking Changes & Migration"**. In short:

- Negated-operator AST shape changed (`IsNot` on the node; `NOT LIKE` → `TokenOperatorNotLike`).
- `DistinctNode` gained a `Value` field.
- `Parse` returns a joined error instead of one formatted string.
- Inputs previously accepted by mistake are now rejected.

Code that only calls `Parse` and checks `err != nil` needs **no changes** (beyond fixing inputs that were never actually valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)