### PR TITLE
feat: add PostgreSQL 18 comparison and pattern-matching predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Query Filters Validator (QFV)
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/slashdevops/qfv.svg)](https://pkg.go.dev/github.com/slashdevops/qfv)
+
 A Go library for parsing and validating query expressions commonly used in REST APIs and database queries. This library provides robust parsing and validation for fields selection, filtering, and sorting operations.
 
 ## Overview
@@ -113,18 +115,28 @@ Parse and validate complex filter expressions like:
 first_name = 'John' AND last_name = 'Doe' OR email = 'example@example.com'
 ```
 
-The filter parser supports:
+The filter parser supports a PostgreSQL-flavored grammar (see
+[PostgreSQL 18: Comparison Functions and Operators](https://www.postgresql.org/docs/18/functions-comparison.html)
+and [Pattern Matching](https://www.postgresql.org/docs/18/functions-matching.html)):
 
-- **Logical operators**: AND, OR, NOT
-- **Comparison operators**: =, <>, !=, <, <=, >, >=
-- **Special operators**: LIKE, IN, BETWEEN, IS NULL, IS NOT NULL, DISTINCT, SIMILAR TO
-- **Regex operators**:
+- **Logical operators**: `AND`, `OR`, `NOT`
+- **Comparison operators**: `=`, `<>`, `!=`, `<`, `<=`, `>`, `>=`
+- **Range predicates**: `BETWEEN`, `NOT BETWEEN`, `BETWEEN SYMMETRIC`, `NOT BETWEEN SYMMETRIC` (and the explicit `ASYMMETRIC` default)
+- **Set membership**: `IN`, `NOT IN`
+- **Null tests**: `IS NULL`, `IS NOT NULL`, plus the non-standard `ISNULL` / `NOTNULL` shorthands
+- **Boolean tests**: `IS TRUE`, `IS NOT TRUE`, `IS FALSE`, `IS NOT FALSE`, `IS UNKNOWN`, `IS NOT UNKNOWN`
+- **Null-safe comparison**: `IS DISTINCT FROM`, `IS NOT DISTINCT FROM`
+- **Pattern matching**:
+  - `LIKE`, `NOT LIKE` (and operator forms `~~`, `!~~`)
+  - `ILIKE`, `NOT ILIKE` — case-insensitive (and operator forms `~~*`, `!~~*`)
+  - `SIMILAR TO`, `NOT SIMILAR TO` — SQL-standard regex
+- **POSIX regex operators**:
   - `~`: Case-sensitive regex match
   - `!~`: Case-sensitive regex non-match
   - `~*`: Case-insensitive regex match
   - `!~*`: Case-insensitive regex non-match
 - **Grouping** with parentheses
-- **Literals**: strings, integers, floats, booleans
+- **Literals**: strings (single-quoted, `''` escapes a quote), integers, floats, booleans (`TRUE`/`FALSE`/`YES`/`NO`)
 
 The parser ensures that:
 
@@ -151,14 +163,31 @@ The parser ensures that:
 "age <> 30"  // Not equal
 "age != 30"  // Not equal (alternative)
 
-// Special operators
+// Pattern matching
 "first_name LIKE 'J%'"
+"first_name NOT LIKE 'J%'"
+"first_name ILIKE 'j%'"       // case-insensitive
+"first_name NOT ILIKE 'j%'"
+"name SIMILAR TO 'J%n'"       // SQL standard regex
+"name NOT SIMILAR TO 'J%n'"
+
+// Set membership & ranges
 "status IN ('active', 'pending')"
+"status NOT IN ('archived')"
 "age BETWEEN 20 AND 30"
+"age NOT BETWEEN 20 AND 30"
+"age BETWEEN SYMMETRIC 30 AND 20" // endpoints auto-sorted
+
+// Null / boolean / null-safe tests
 "middle_name IS NULL"
 "middle_name IS NOT NULL"
-"name SIMILAR TO 'J%n'" // SQL standard regex
-"name NOT SIMILAR TO 'J%n'"
+"middle_name ISNULL"              // shorthand
+"middle_name NOTNULL"            // shorthand
+"active IS TRUE"
+"active IS NOT FALSE"
+"active IS UNKNOWN"
+"age IS DISTINCT FROM 30"        // null-safe !=
+"age IS NOT DISTINCT FROM 30"    // null-safe =
 "email ~ '^[^@]+@[^@]+\.[^@]+$'" // Case-sensitive regex match
 "email !~ '^[^@]+@[^@]+\.[^@]+$'" // Case-sensitive regex non-match
 "email ~* '(?i)^admin@'" // Case-insensitive regex match (using Go regex flag)
@@ -272,3 +301,31 @@ Code that only checked `err != nil` is unaffected.
 A single `*FilterParser` (like `*SortParser` and `*FieldsParser`) can now be
 created once and shared across goroutines; per-request state is no longer stored
 on the parser. No API change — this simply removes a data race.
+
+### 6. New PostgreSQL 18 predicates and operators (additive)
+
+The filter grammar gained the following predicates, aligned with
+[PostgreSQL 18](https://www.postgresql.org/docs/18/functions-comparison.html).
+These are additive — existing queries keep parsing — with the AST notes below:
+
+| Predicate / operator | AST node |
+| --- | --- |
+| `ILIKE`, `NOT ILIKE` (and `~~`, `~~*`, `!~~`, `!~~*`) | `BinaryOperatorNode` with `Operator` `ILIKE` / `NOT ILIKE` (or `LIKE` / `NOT LIKE` for the plain forms) |
+| `IS [NOT] TRUE`, `IS [NOT] FALSE`, `IS [NOT] UNKNOWN` | new `BooleanTestNode{Field, Value, IsNot}` (`Value` is `BooleanTrue`/`BooleanFalse`/`BooleanUnknown`) |
+| `IS [NOT] DISTINCT FROM <value>` | `DistinctNode` (now reachable via the standard `IS` form) |
+| `BETWEEN [NOT] SYMMETRIC` (and explicit `ASYMMETRIC`) | `BetweenNode` gained `IsSymmetric bool` |
+| `ISNULL`, `NOTNULL` shorthands | `IsNullNode` (with `IsNot=true` for `NOTNULL`) |
+
+Two node changes accompany these:
+
+- `DistinctNode` gained a `Value Node` field (the right-hand side of
+  `IS [NOT] DISTINCT FROM`), and its `String()` now renders the canonical
+  `field IS [NOT] DISTINCT FROM value` form (previously `field DISTINCT FROM value`).
+- `BetweenNode` gained an `IsSymmetric bool` field; `String()` appends
+  `SYMMETRIC` when set.
+
+> Note on `ILIKE`/regex operators: the parser validates that the right-hand side
+> is a **string literal**, but it does not compile the pattern. If you evaluate
+> the pattern with Go's `regexp`, validate/compile it yourself. Single-quoted
+> string literals treat backslashes literally (only `''` is an escape), so a
+> regex like `'^\d+$'` reaches you with the backslash intact.

--- a/example_doc_test.go
+++ b/example_doc_test.go
@@ -1,0 +1,87 @@
+package qfv_test
+
+import (
+	"errors"
+	"fmt"
+
+	qfv "github.com/slashdevops/qfv"
+)
+
+// allowed is the set of fields an API is willing to expose to clients.
+var allowed = []string{"first_name", "last_name", "email", "age", "active", "created_at"}
+
+func ExampleFieldsParser() {
+	parser := qfv.NewFieldsParser(allowed)
+
+	node, err := parser.Parse("first_name, email")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	for _, f := range node.Fields {
+		fmt.Println(f)
+	}
+	// Output:
+	// first_name
+	// email
+}
+
+func ExampleSortParser() {
+	parser := qfv.NewSortParser(allowed)
+
+	node, err := parser.Parse("first_name ASC, created_at DESC")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	for _, f := range node.Fields {
+		fmt.Printf("%s %s\n", f.Field, f.Direction)
+	}
+	// Output:
+	// first_name ASC
+	// created_at DESC
+}
+
+func ExampleFilterParser() {
+	parser := qfv.NewFilterParser(allowed)
+
+	node, err := parser.Parse("first_name = 'John' AND age >= 18")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(node.String())
+	// Output:
+	// ((first_name = 'John') AND (age >= 18))
+}
+
+// ExampleFilterParser_postgres shows the PostgreSQL predicates: case-insensitive
+// ILIKE, IS [NOT] DISTINCT FROM (null-safe comparison), and IS boolean tests.
+func ExampleFilterParser_postgres() {
+	parser := qfv.NewFilterParser(allowed)
+
+	node, err := parser.Parse("email ILIKE '%@EXAMPLE.com' AND age IS NOT DISTINCT FROM 30 OR active IS TRUE")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(node.String())
+	// Output:
+	// (((email ILIKE '%@EXAMPLE.com') AND age IS NOT DISTINCT FROM 30) OR active IS TRUE)
+}
+
+// ExampleFilterParser_errorInspection shows how to inspect validation failures.
+// Parse aggregates every problem with errors.Join, so errors.As extracts the
+// first *QFVFilterError cause.
+func ExampleFilterParser_errorInspection() {
+	parser := qfv.NewFilterParser(allowed)
+
+	_, err := parser.Parse("secret = 'x'")
+
+	var fe *qfv.QFVFilterError
+	if errors.As(err, &fe) {
+		fmt.Printf("field %q rejected: %s\n", fe.Field, fe.Message)
+	}
+	// Output:
+	// field "secret" rejected: field not allowed
+}

--- a/filter_errors_test.go
+++ b/filter_errors_test.go
@@ -1,0 +1,66 @@
+package qfv
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestQFVFilterError_Error(t *testing.T) {
+	withField := &QFVFilterError{Field: "name", Message: "bad"}
+	if got, want := withField.Error(), "error on field 'name': bad"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+	noField := &QFVFilterError{Message: "bad"}
+	if got, want := noField.Error(), "error: bad"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+// TestParse_JoinedErrorsAreInspectable verifies the aggregated error can be
+// unwrapped into *QFVFilterError values via errors.As.
+func TestParse_JoinedErrorsAreInspectable(t *testing.T) {
+	p := NewFilterParser([]string{"name"})
+	_, err := p.Parse("unknown = 'x'")
+	if err == nil {
+		t.Fatal("expected error for disallowed field")
+	}
+	var fe *QFVFilterError
+	if !errors.As(err, &fe) {
+		t.Fatalf("errors.As failed to extract *QFVFilterError from %T", err)
+	}
+	if fe.Field != "unknown" {
+		t.Errorf("Field = %q, want unknown", fe.Field)
+	}
+}
+
+func TestNode_TypeMethods(t *testing.T) {
+	if got := (FieldsNode{}).Type(); got != NodeTypeFieldList {
+		t.Errorf("FieldsNode.Type() = %s", got)
+	}
+	if got := (SortNode{}).Type(); got != NodeTypeSort {
+		t.Errorf("SortNode.Type() = %s", got)
+	}
+	if got := (SortFieldNode{}).Type(); got != NodeTypeSortField {
+		t.Errorf("SortFieldNode.Type() = %s", got)
+	}
+}
+
+// TestFilterParser_ErrorBranches drives the IN/BETWEEN error paths.
+func TestFilterParser_ErrorBranches(t *testing.T) {
+	p := NewFilterParser([]string{"name", "age"})
+	cases := []string{
+		"name IN ()",        // empty list
+		"name IN ('x',)",    // trailing comma
+		"name IN 'x'",       // missing opening paren
+		"name IN ('x'",      // missing closing paren
+		"age BETWEEN 10",    // missing AND
+		"age BETWEEN 10 20", // missing AND keyword
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if _, err := p.Parse(in); err == nil {
+				t.Errorf("Parse(%q) = nil error, want error", in)
+			}
+		})
+	}
+}

--- a/filter_lexer.go
+++ b/filter_lexer.go
@@ -54,6 +54,8 @@ func (l *Lexer) Parse() {
 					tok = TokenOperatorOr
 				case "LIKE":
 					tok = TokenOperatorLike
+				case "ILIKE":
+					tok = TokenOperatorILike
 				case "IN":
 					tok = TokenOperatorIn
 				case "BETWEEN":
@@ -155,8 +157,18 @@ func (l *Lexer) Parse() {
 				tok = TokenOperatorNotEqualAlias
 				lit = "!="
 			} else if l.s.Peek() == '~' {
-				l.s.Scan() // Consume '~'
-				if l.s.Peek() == '*' {
+				l.s.Scan() // Consume first '~'
+				if l.s.Peek() == '~' {
+					l.s.Scan() // Consume second '~' -> !~~ family (NOT LIKE)
+					if l.s.Peek() == '*' {
+						l.s.Scan() // Consume '*'
+						tok = TokenOperatorNotILike
+						lit = "!~~*"
+					} else {
+						tok = TokenOperatorNotLike
+						lit = "!~~"
+					}
+				} else if l.s.Peek() == '*' {
 					l.s.Scan() // Consume '*'
 					tok = TokenOperatorNotRegexMatchCI
 					lit = "!~*"
@@ -171,7 +183,17 @@ func (l *Lexer) Parse() {
 				lit = "!" // Keep literal for error message
 			}
 		case '~':
-			if l.s.Peek() == '*' {
+			if l.s.Peek() == '~' {
+				l.s.Scan() // Consume second '~' -> ~~ family (LIKE)
+				if l.s.Peek() == '*' {
+					l.s.Scan() // Consume '*'
+					tok = TokenOperatorILike
+					lit = "~~*"
+				} else {
+					tok = TokenOperatorLike
+					lit = "~~"
+				}
+			} else if l.s.Peek() == '*' {
 				l.s.Scan() // Consume '*'
 				tok = TokenOperatorRegexMatchCI
 				lit = "~*"

--- a/filter_nodes.go
+++ b/filter_nodes.go
@@ -28,6 +28,7 @@ const (
 	NodeTypeSimilarTo      NodeType = "SIMILAR_TO"      // (field, pattern) -> name SIMILAR TO "pattern"
 	NodeTypeNotSimilarTo   NodeType = "NOT_SIMILAR_TO"  // (field, pattern) -> name NOT SIMILAR TO "pattern"
 	NodeTypeRegexMatch     NodeType = "REGEX_MATCH"     // (field, pattern, is_not, is_case_insensitive) -> name ~ 'pattern'
+	NodeTypeBooleanTest    NodeType = "BOOLEAN_TEST"    // (field, test, is_not) -> active IS TRUE, active IS NOT FALSE
 
 	NodeTypeSort      NodeType = "SORT"       // (field, direction) -> name ASC, age DESC
 	NodeTypeSortField NodeType = "SORT_FIELD" // (field, direction) -> name ASC, age DESC
@@ -232,24 +233,53 @@ func (n *DistinctNode) Type() NodeType {
 	return NodeTypeDistinct
 }
 func (n *DistinctNode) String() string {
-	op := "DISTINCT"
+	op := "IS DISTINCT FROM"
 	if n.IsNot {
-		op = "NOT DISTINCT"
+		op = "IS NOT DISTINCT FROM"
 	}
 	if n.Value != nil {
-		return fmt.Sprintf("%s %s FROM %s", n.Field.String(), op, n.Value.String())
+		return fmt.Sprintf("%s %s %s", n.Field.String(), op, n.Value.String())
 	}
-	return fmt.Sprintf("%s %s", n.Field.String(), op)
+	// Value omitted (not expected in normal parses); drop the trailing FROM.
+	return fmt.Sprintf("%s %s", n.Field.String(), strings.TrimSuffix(op, " FROM"))
 }
 func (n *DistinctNode) Pos() scanner.Position { return n.pos }
+
+// BooleanTruthValue is the truth value tested by a BooleanTestNode.
+type BooleanTruthValue string
+
+const (
+	BooleanTrue    BooleanTruthValue = "TRUE"
+	BooleanFalse   BooleanTruthValue = "FALSE"
+	BooleanUnknown BooleanTruthValue = "UNKNOWN"
+)
+
+// BooleanTestNode represents an IS [NOT] TRUE/FALSE/UNKNOWN expression
+// (e.g., active IS TRUE, active IS NOT FALSE).
+type BooleanTestNode struct {
+	baseNode
+	Field Node
+	Value BooleanTruthValue // TRUE, FALSE, or UNKNOWN
+	IsNot bool              // true for IS NOT <value>
+}
+
+func (n *BooleanTestNode) Type() NodeType { return NodeTypeBooleanTest }
+func (n *BooleanTestNode) String() string {
+	if n.IsNot {
+		return fmt.Sprintf("%s IS NOT %s", n.Field.String(), n.Value)
+	}
+	return fmt.Sprintf("%s IS %s", n.Field.String(), n.Value)
+}
+func (n *BooleanTestNode) Pos() scanner.Position { return n.pos }
 
 // BetweenNode represents a BETWEEN expression (e.g., age BETWEEN 30 AND 40)
 type BetweenNode struct {
 	baseNode
-	Field Node
-	Lower Node
-	Upper Node
-	IsNot bool // true for NOT BETWEEN
+	Field       Node
+	Lower       Node
+	Upper       Node
+	IsNot       bool // true for NOT BETWEEN
+	IsSymmetric bool // true for BETWEEN SYMMETRIC / NOT BETWEEN SYMMETRIC
 }
 
 func (n *BetweenNode) Type() NodeType {
@@ -262,6 +292,9 @@ func (n *BetweenNode) String() string {
 	op := "BETWEEN"
 	if n.IsNot {
 		op = "NOT BETWEEN"
+	}
+	if n.IsSymmetric {
+		op += " SYMMETRIC"
 	}
 	return fmt.Sprintf("%s %s %s AND %s", n.Field.String(), op, n.Lower.String(), n.Upper.String())
 }

--- a/filter_nodes_string_test.go
+++ b/filter_nodes_string_test.go
@@ -1,0 +1,171 @@
+package qfv
+
+import (
+	"reflect"
+	"testing"
+	"text/scanner"
+)
+
+func lit(s string) *LiteralNode {
+	return &LiteralNode{Value: s, Kind: reflect.String, Text: "'" + s + "'"}
+}
+
+func ident(name string) *IdentifierNode { return &IdentifierNode{Name: name} }
+
+// TestNodeStringRepresentations covers String()/Type()/Pos() for every node,
+// including the negated and case-insensitive variants.
+func TestNodeStringRepresentations(t *testing.T) {
+	pos := scanner.Position{Filename: "t", Line: 2, Column: 3}
+
+	tests := []struct {
+		name     string
+		node     Node
+		wantType NodeType
+		wantStr  string
+	}{
+		{
+			name:     "UnaryOperator NOT",
+			node:     &UnaryOperatorNode{baseNode: baseNode{pos: pos}, Operator: TokenOperatorNot, X: lit("x")},
+			wantType: NodeTypeUnaryOperator,
+			wantStr:  "(NOT 'x')",
+		},
+		{
+			name:     "BinaryOperator AND",
+			node:     &BinaryOperatorNode{baseNode: baseNode{pos: pos}, Left: ident("a"), Right: lit("x"), Operator: TokenOperatorAnd},
+			wantType: NodeTypeBinaryOperator,
+			wantStr:  "(a AND 'x')",
+		},
+		{
+			name:     "Group",
+			node:     &GroupNode{baseNode: baseNode{pos: pos}, Expression: ident("a")},
+			wantType: NodeTypeGroup,
+			wantStr:  "(a)",
+		},
+		{
+			name:     "IsNull IS NOT NULL",
+			node:     &IsNullNode{baseNode: baseNode{pos: pos}, Field: ident("a"), IsNot: true},
+			wantType: NodeTypeIsNotNull,
+			wantStr:  "a IS NOT NULL",
+		},
+		{
+			name:     "In NOT IN",
+			node:     &InNode{baseNode: baseNode{pos: pos}, Field: ident("a"), IsNot: true, Values: []Node{lit("x"), lit("y")}},
+			wantType: NodeTypeNotIn,
+			wantStr:  "a NOT IN ('x', 'y')",
+		},
+		{
+			name:     "Between NOT SYMMETRIC",
+			node:     &BetweenNode{baseNode: baseNode{pos: pos}, Field: ident("age"), Lower: lit("1"), Upper: lit("9"), IsNot: true, IsSymmetric: true},
+			wantType: NodeTypeNotBetween,
+			wantStr:  "age NOT BETWEEN SYMMETRIC '1' AND '9'",
+		},
+		{
+			name:     "SimilarTo NOT",
+			node:     &SimilarToNode{baseNode: baseNode{pos: pos}, Field: ident("a"), Pattern: lit("p"), IsNot: true},
+			wantType: NodeTypeNotSimilarTo,
+			wantStr:  "a NOT SIMILAR TO 'p'",
+		},
+		{
+			name:     "SimilarTo plain",
+			node:     &SimilarToNode{baseNode: baseNode{pos: pos}, Field: ident("a"), Pattern: lit("p")},
+			wantType: NodeTypeSimilarTo,
+			wantStr:  "a SIMILAR TO 'p'",
+		},
+		{
+			name:     "Distinct without value",
+			node:     &DistinctNode{baseNode: baseNode{pos: pos}, Field: ident("a")},
+			wantType: NodeTypeDistinct,
+			wantStr:  "a IS DISTINCT",
+		},
+		{
+			name:     "BooleanTest IS FALSE",
+			node:     &BooleanTestNode{baseNode: baseNode{pos: pos}, Field: ident("ok"), Value: BooleanFalse},
+			wantType: NodeTypeBooleanTest,
+			wantStr:  "ok IS FALSE",
+		},
+		{
+			name:     "RegexMatch CS",
+			node:     &RegexMatchNode{baseNode: baseNode{pos: pos}, Field: ident("a"), Pattern: lit("p")},
+			wantType: NodeTypeRegexMatch,
+			wantStr:  "a ~ 'p'",
+		},
+		{
+			name:     "RegexMatch NOT CI",
+			node:     &RegexMatchNode{baseNode: baseNode{pos: pos}, Field: ident("a"), Pattern: lit("p"), IsNot: true, IsCaseInsensitive: true},
+			wantType: NodeTypeRegexMatch,
+			wantStr:  "a !~* 'p'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.node.Type(); got != tt.wantType {
+				t.Errorf("Type() = %s, want %s", got, tt.wantType)
+			}
+			if got := tt.node.String(); got != tt.wantStr {
+				t.Errorf("String() = %q, want %q", got, tt.wantStr)
+			}
+			if got := tt.node.Pos(); got != pos {
+				t.Errorf("Pos() = %v, want %v", got, pos)
+			}
+		})
+	}
+}
+
+// TestLexerCursorHelpers covers Peek/Next/Backup/Current.
+func TestLexerCursorHelpers(t *testing.T) {
+	l := NewLexer("a = 'x'")
+	l.Parse()
+
+	if got := l.Peek().Value; got != "a" {
+		t.Errorf("Peek() before consuming = %q, want a", got)
+	}
+	first := l.Next()
+	if first.Value != "a" {
+		t.Errorf("Next() = %q, want a", first.Value)
+	}
+	if got := l.Current().Value; got != "a" {
+		t.Errorf("Current() = %q, want a", got)
+	}
+	// Peek should show the next token without consuming.
+	if got := l.Peek().Type; got != TokenOperatorEqual {
+		t.Errorf("Peek() = %s, want =", got)
+	}
+	l.Next() // '='
+	l.Backup()
+	if got := l.Next().Type; got != TokenOperatorEqual {
+		t.Errorf("after Backup, Next() = %s, want =", got)
+	}
+}
+
+// TestParsePrimaryLiteralKinds ensures int, float and boolean literals parse.
+func TestParsePrimaryLiteralKinds(t *testing.T) {
+	p := NewFilterParser([]string{"age", "score", "active"})
+
+	cases := map[string]reflect.Kind{
+		"age = 30":       reflect.Int64,
+		"score = 3.14":   reflect.Float64,
+		"active = true":  reflect.Bool,
+		"active = false": reflect.Bool,
+		"active = YES":   reflect.Bool,
+	}
+	for in, wantKind := range cases {
+		t.Run(in, func(t *testing.T) {
+			node, err := p.Parse(in)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", in, err)
+			}
+			bin, ok := node.(*BinaryOperatorNode)
+			if !ok {
+				t.Fatalf("expected *BinaryOperatorNode, got %T", node)
+			}
+			rhs, ok := bin.Right.(*LiteralNode)
+			if !ok {
+				t.Fatalf("expected *LiteralNode rhs, got %T", bin.Right)
+			}
+			if rhs.Kind != wantKind {
+				t.Errorf("Kind = %v, want %v", rhs.Kind, wantKind)
+			}
+		})
+	}
+}

--- a/filter_nodes_test.go
+++ b/filter_nodes_test.go
@@ -314,7 +314,7 @@ func TestDistinctNode(t *testing.T) {
 	})
 
 	t.Run("String", func(t *testing.T) {
-		expected := "fieldName DISTINCT"
+		expected := "fieldName IS DISTINCT"
 		if got := node.String(); got != expected {
 			t.Errorf("DistinctNode.String() = %v, want %v", got, expected)
 		}

--- a/filter_parser.go
+++ b/filter_parser.go
@@ -197,6 +197,21 @@ func (p *filterParseState) parseComparison() Node {
 			p.addError(&QFVFilterError{Field: field.Name, Message: "field not allowed"})
 		}
 
+		// Non-standard PostgreSQL shorthands: `field ISNULL` and `field NOTNULL`.
+		// These are single identifier tokens (unlike the `IS [NOT] NULL` keywords).
+		if p.currentToken.Type == TokenIdentifier {
+			switch strings.ToUpper(p.currentToken.Value) {
+			case "ISNULL":
+				pos := p.currentToken.Pos
+				p.nextToken()
+				return &IsNullNode{baseNode: baseNode{pos: pos}, Field: field, IsNot: false}
+			case "NOTNULL":
+				pos := p.currentToken.Pos
+				p.nextToken()
+				return &IsNullNode{baseNode: baseNode{pos: pos}, Field: field, IsNot: true}
+			}
+		}
+
 		// Handle different operators
 		switch p.currentToken.Type {
 		case TokenOperatorEqual, TokenOperatorNotEqual, TokenOperatorNotEqualAlias,
@@ -204,8 +219,17 @@ func (p *filterParseState) parseComparison() Node {
 			TokenOperatorGreaterThan, TokenOperatorGreaterThanOrEqualTo:
 			return p.parseComparisonOperator(field)
 		case TokenOperatorLike:
-			p.nextToken() // Consume LIKE
-			return p.parseLikeOperator(field, false)
+			p.nextToken() // Consume LIKE (or ~~)
+			return p.parseLikeOperator(field, TokenOperatorLike)
+		case TokenOperatorILike:
+			p.nextToken() // Consume ILIKE (or ~~*)
+			return p.parseLikeOperator(field, TokenOperatorILike)
+		case TokenOperatorNotLike:
+			p.nextToken() // Consume !~~ (operator form of NOT LIKE)
+			return p.parseLikeOperator(field, TokenOperatorNotLike)
+		case TokenOperatorNotILike:
+			p.nextToken() // Consume !~~* (operator form of NOT ILIKE)
+			return p.parseLikeOperator(field, TokenOperatorNotILike)
 		case TokenOperatorIn:
 			p.nextToken() // Consume IN
 			return p.parseInOperator(field, false)
@@ -214,7 +238,7 @@ func (p *filterParseState) parseComparison() Node {
 			return p.parseBetweenOperator(field, false)
 		case TokenOperatorIsNull:
 			p.nextToken() // Consume IS
-			return p.parseIsNullOperator(field)
+			return p.parseIsPredicate(field)
 		case TokenOperatorDistinct:
 			p.nextToken() // Consume DISTINCT
 			return p.parseDistinctOperator(field, false)
@@ -258,7 +282,10 @@ func (p *filterParseState) parseComparison() Node {
 				return p.parseBetweenOperator(field, true)
 			case TokenOperatorLike:
 				p.nextToken() // Consume LIKE
-				return p.parseLikeOperator(field, true)
+				return p.parseLikeOperator(field, TokenOperatorNotLike)
+			case TokenOperatorILike:
+				p.nextToken() // Consume ILIKE
+				return p.parseLikeOperator(field, TokenOperatorNotILike)
 			case TokenOperatorSimilarTo:
 				p.nextToken() // Consume SIMILAR
 				return p.parseSimilarToOperator(field, true)
@@ -312,15 +339,13 @@ func (p *filterParseState) parseSimilarToOperator(field Node, isNot bool) Node {
 	}
 }
 
-// parseLikeOperator parses LIKE operator
-// Expects the current token to be the pattern after LIKE was consumed.
-func (p *filterParseState) parseLikeOperator(field Node, isNot bool) Node {
-	pos := p.lexer.Current().Pos // Use position of LIKE token (already consumed)
+// parseLikeOperator parses a LIKE/ILIKE/NOT LIKE/NOT ILIKE operator.
+// Expects the current token to be the pattern after the operator was consumed.
+// operator is one of TokenOperatorLike, TokenOperatorILike, TokenOperatorNotLike,
+// or TokenOperatorNotILike.
+func (p *filterParseState) parseLikeOperator(field Node, operator TokenType) Node {
+	pos := p.lexer.Current().Pos // Use position of the operator token (already consumed)
 	pattern := p.parsePrimary()
-	operator := TokenOperatorLike
-	if isNot {
-		operator = TokenOperatorNotLike
-	}
 	return &BinaryOperatorNode{
 		baseNode: baseNode{pos: pos},
 		Left:     field,
@@ -372,6 +397,19 @@ func (p *filterParseState) parseInOperator(field Node, isNot bool) Node {
 // Expects the current token to be the lower bound after BETWEEN was consumed.
 func (p *filterParseState) parseBetweenOperator(field Node, isNot bool) Node {
 	pos := p.lexer.Current().Pos // Use position of BETWEEN token (already consumed)
+
+	// Optional SYMMETRIC / ASYMMETRIC modifier (ASYMMETRIC is the default).
+	isSymmetric := false
+	if p.currentToken.Type == TokenIdentifier {
+		switch strings.ToUpper(p.currentToken.Value) {
+		case "SYMMETRIC":
+			isSymmetric = true
+			p.nextToken()
+		case "ASYMMETRIC":
+			p.nextToken()
+		}
+	}
+
 	lower := p.parsePrimary()
 
 	if !p.expect(TokenOperatorAnd) {
@@ -382,17 +420,23 @@ func (p *filterParseState) parseBetweenOperator(field Node, isNot bool) Node {
 	upper := p.parsePrimary()
 
 	return &BetweenNode{
-		baseNode: baseNode{pos: pos},
-		Field:    field,
-		Lower:    lower,
-		Upper:    upper,
-		IsNot:    isNot,
+		baseNode:    baseNode{pos: pos},
+		Field:       field,
+		Lower:       lower,
+		Upper:       upper,
+		IsNot:       isNot,
+		IsSymmetric: isSymmetric,
 	}
 }
 
-// parseIsNullOperator parses IS [NOT] NULL operator
-// Expects the current token to be NOT or NULL after IS was consumed.
-func (p *filterParseState) parseIsNullOperator(field Node) Node {
+// parseIsPredicate parses the family of IS predicates after IS was consumed:
+//
+//	IS [NOT] NULL
+//	IS [NOT] TRUE | FALSE | UNKNOWN
+//	IS [NOT] DISTINCT FROM <value>
+//
+// Expects the current token to be NOT or the predicate keyword.
+func (p *filterParseState) parseIsPredicate(field Node) Node {
 	pos := p.lexer.Current().Pos // Use position of IS token (already consumed)
 	isNot := false
 	if p.currentToken.Type == TokenOperatorNot {
@@ -400,20 +444,34 @@ func (p *filterParseState) parseIsNullOperator(field Node) Node {
 		p.nextToken() // Consume NOT
 	}
 
-	// Check for NULL
-	if p.currentToken.Type == TokenIdentifier && strings.ToUpper(p.currentToken.Value) == "NULL" {
-		p.nextToken() // Consume NULL
-		return &IsNullNode{
-			baseNode: baseNode{pos: pos},
-			Field:    field,
-			IsNot:    isNot,
+	switch {
+	case p.currentToken.Type == TokenOperatorDistinct:
+		// IS [NOT] DISTINCT FROM <value>
+		p.nextToken() // Consume DISTINCT
+		return p.parseDistinctOperator(field, isNot)
+
+	case p.currentToken.Type == TokenBoolean:
+		// IS [NOT] TRUE | FALSE (TRUE/YES and FALSE/NO are lexed as booleans)
+		truth := BooleanTrue
+		if v := strings.ToUpper(p.currentToken.Value); v == "FALSE" || v == "NO" {
+			truth = BooleanFalse
 		}
+		p.nextToken() // Consume TRUE/FALSE
+		return &BooleanTestNode{baseNode: baseNode{pos: pos}, Field: field, Value: truth, IsNot: isNot}
+
+	case p.currentToken.Type == TokenIdentifier && strings.ToUpper(p.currentToken.Value) == "NULL":
+		p.nextToken() // Consume NULL
+		return &IsNullNode{baseNode: baseNode{pos: pos}, Field: field, IsNot: isNot}
+
+	case p.currentToken.Type == TokenIdentifier && strings.ToUpper(p.currentToken.Value) == "UNKNOWN":
+		p.nextToken() // Consume UNKNOWN
+		return &BooleanTestNode{baseNode: baseNode{pos: pos}, Field: field, Value: BooleanUnknown, IsNot: isNot}
 	}
 
 	if isNot {
-		p.addError(&QFVFilterError{Message: "expected NULL after IS NOT"})
+		p.addError(&QFVFilterError{Message: "expected NULL, TRUE, FALSE, UNKNOWN, or DISTINCT FROM after IS NOT"})
 	} else {
-		p.addError(&QFVFilterError{Message: "expected NULL or NOT NULL after IS"})
+		p.addError(&QFVFilterError{Message: "expected NULL, TRUE, FALSE, UNKNOWN, or DISTINCT FROM after IS"})
 	}
 	return field // Return field on error
 }

--- a/filter_parser_regression_test.go
+++ b/filter_parser_regression_test.go
@@ -52,7 +52,7 @@ func TestFilterParser_DistinctPreservesValue(t *testing.T) {
 	if d.Value == nil {
 		t.Fatal("expected DISTINCT FROM value to be preserved, got nil")
 	}
-	if got, want := d.String(), "name DISTINCT FROM 'John'"; got != want {
+	if got, want := d.String(), "name IS DISTINCT FROM 'John'"; got != want {
 		t.Errorf("String() = %q, want %q", got, want)
 	}
 }

--- a/filter_pg_predicates_test.go
+++ b/filter_pg_predicates_test.go
@@ -1,0 +1,285 @@
+package qfv
+
+import "testing"
+
+// TestFilterParser_PostgreSQLPredicates exercises the PostgreSQL 18 comparison
+// and pattern-matching predicates added to the grammar.
+func TestFilterParser_PostgreSQLPredicates(t *testing.T) {
+	allowed := []string{"name", "email", "age", "active", "status"}
+
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		checkNode func(t *testing.T, node Node)
+	}{
+		// ---- ILIKE / NOT ILIKE ----
+		{
+			name:  "ILIKE keyword",
+			input: "name ILIKE 'jo%'",
+			checkNode: func(t *testing.T, node Node) {
+				b := mustBinary(t, node)
+				if b.Operator != TokenOperatorILike {
+					t.Errorf("operator = %s, want ILIKE", b.Operator)
+				}
+			},
+		},
+		{
+			name:  "NOT ILIKE keyword",
+			input: "name NOT ILIKE 'jo%'",
+			checkNode: func(t *testing.T, node Node) {
+				if got := mustBinary(t, node).Operator; got != TokenOperatorNotILike {
+					t.Errorf("operator = %s, want NOT ILIKE", got)
+				}
+			},
+		},
+		{
+			name:  "~~ operator is LIKE",
+			input: "name ~~ 'jo%'",
+			checkNode: func(t *testing.T, node Node) {
+				if got := mustBinary(t, node).Operator; got != TokenOperatorLike {
+					t.Errorf("operator = %s, want LIKE", got)
+				}
+			},
+		},
+		{
+			name:  "~~* operator is ILIKE",
+			input: "name ~~* 'jo%'",
+			checkNode: func(t *testing.T, node Node) {
+				if got := mustBinary(t, node).Operator; got != TokenOperatorILike {
+					t.Errorf("operator = %s, want ILIKE", got)
+				}
+			},
+		},
+		{
+			name:  "!~~ operator is NOT LIKE",
+			input: "name !~~ 'jo%'",
+			checkNode: func(t *testing.T, node Node) {
+				if got := mustBinary(t, node).Operator; got != TokenOperatorNotLike {
+					t.Errorf("operator = %s, want NOT LIKE", got)
+				}
+			},
+		},
+		{
+			name:  "!~~* operator is NOT ILIKE",
+			input: "name !~~* 'jo%'",
+			checkNode: func(t *testing.T, node Node) {
+				if got := mustBinary(t, node).Operator; got != TokenOperatorNotILike {
+					t.Errorf("operator = %s, want NOT ILIKE", got)
+				}
+			},
+		},
+
+		// ---- IS [NOT] DISTINCT FROM ----
+		{
+			name:  "IS DISTINCT FROM",
+			input: "age IS DISTINCT FROM 30",
+			checkNode: func(t *testing.T, node Node) {
+				d, ok := node.(*DistinctNode)
+				if !ok {
+					t.Fatalf("expected *DistinctNode, got %T", node)
+				}
+				if d.IsNot {
+					t.Error("expected IsNot=false")
+				}
+				if d.Value == nil {
+					t.Error("expected value preserved")
+				}
+				if got, want := d.String(), "age IS DISTINCT FROM 30"; got != want {
+					t.Errorf("String() = %q, want %q", got, want)
+				}
+			},
+		},
+		{
+			name:  "IS NOT DISTINCT FROM",
+			input: "age IS NOT DISTINCT FROM 30",
+			checkNode: func(t *testing.T, node Node) {
+				d, ok := node.(*DistinctNode)
+				if !ok {
+					t.Fatalf("expected *DistinctNode, got %T", node)
+				}
+				if !d.IsNot {
+					t.Error("expected IsNot=true")
+				}
+				if d.Type() != NodeTypeNotDistinct {
+					t.Errorf("Type() = %s, want NOT_DISTINCT", d.Type())
+				}
+			},
+		},
+
+		// ---- IS [NOT] TRUE / FALSE / UNKNOWN ----
+		{
+			name:  "IS TRUE",
+			input: "active IS TRUE",
+			checkNode: func(t *testing.T, node Node) {
+				checkBoolTest(t, node, BooleanTrue, false)
+			},
+		},
+		{
+			name:  "IS NOT TRUE",
+			input: "active IS NOT TRUE",
+			checkNode: func(t *testing.T, node Node) {
+				checkBoolTest(t, node, BooleanTrue, true)
+			},
+		},
+		{
+			name:  "IS FALSE",
+			input: "active IS FALSE",
+			checkNode: func(t *testing.T, node Node) {
+				checkBoolTest(t, node, BooleanFalse, false)
+			},
+		},
+		{
+			name:  "IS NOT FALSE",
+			input: "active IS NOT FALSE",
+			checkNode: func(t *testing.T, node Node) {
+				checkBoolTest(t, node, BooleanFalse, true)
+			},
+		},
+		{
+			name:  "IS UNKNOWN",
+			input: "active IS UNKNOWN",
+			checkNode: func(t *testing.T, node Node) {
+				checkBoolTest(t, node, BooleanUnknown, false)
+			},
+		},
+		{
+			name:  "IS NOT UNKNOWN",
+			input: "active IS NOT UNKNOWN",
+			checkNode: func(t *testing.T, node Node) {
+				n := checkBoolTest(t, node, BooleanUnknown, true)
+				if got, want := n.String(), "active IS NOT UNKNOWN"; got != want {
+					t.Errorf("String() = %q, want %q", got, want)
+				}
+			},
+		},
+
+		// ---- BETWEEN SYMMETRIC ----
+		{
+			name:  "BETWEEN SYMMETRIC",
+			input: "age BETWEEN SYMMETRIC 30 AND 10",
+			checkNode: func(t *testing.T, node Node) {
+				b, ok := node.(*BetweenNode)
+				if !ok {
+					t.Fatalf("expected *BetweenNode, got %T", node)
+				}
+				if !b.IsSymmetric {
+					t.Error("expected IsSymmetric=true")
+				}
+				if b.IsNot {
+					t.Error("expected IsNot=false")
+				}
+			},
+		},
+		{
+			name:  "NOT BETWEEN SYMMETRIC",
+			input: "age NOT BETWEEN SYMMETRIC 30 AND 10",
+			checkNode: func(t *testing.T, node Node) {
+				b, ok := node.(*BetweenNode)
+				if !ok {
+					t.Fatalf("expected *BetweenNode, got %T", node)
+				}
+				if !b.IsSymmetric || !b.IsNot {
+					t.Errorf("expected IsSymmetric=true IsNot=true, got %v %v", b.IsSymmetric, b.IsNot)
+				}
+				if got, want := b.String(), "age NOT BETWEEN SYMMETRIC 30 AND 10"; got != want {
+					t.Errorf("String() = %q, want %q", got, want)
+				}
+			},
+		},
+		{
+			name:  "BETWEEN ASYMMETRIC is default",
+			input: "age BETWEEN ASYMMETRIC 10 AND 30",
+			checkNode: func(t *testing.T, node Node) {
+				b, ok := node.(*BetweenNode)
+				if !ok {
+					t.Fatalf("expected *BetweenNode, got %T", node)
+				}
+				if b.IsSymmetric {
+					t.Error("expected IsSymmetric=false for ASYMMETRIC")
+				}
+			},
+		},
+
+		// ---- ISNULL / NOTNULL shorthands ----
+		{
+			name:  "ISNULL shorthand",
+			input: "email ISNULL",
+			checkNode: func(t *testing.T, node Node) {
+				n, ok := node.(*IsNullNode)
+				if !ok {
+					t.Fatalf("expected *IsNullNode, got %T", node)
+				}
+				if n.IsNot {
+					t.Error("expected IsNot=false")
+				}
+			},
+		},
+		{
+			name:  "NOTNULL shorthand",
+			input: "email NOTNULL",
+			checkNode: func(t *testing.T, node Node) {
+				n, ok := node.(*IsNullNode)
+				if !ok {
+					t.Fatalf("expected *IsNullNode, got %T", node)
+				}
+				if !n.IsNot {
+					t.Error("expected IsNot=true")
+				}
+				if got, want := n.String(), "email IS NOT NULL"; got != want {
+					t.Errorf("String() = %q, want %q", got, want)
+				}
+			},
+		},
+
+		// ---- error cases ----
+		{name: "IS with typo", input: "active IS TRU", wantErr: true},
+		{name: "IS DISTINCT without FROM", input: "age IS DISTINCT 30", wantErr: true},
+		{name: "ILIKE without pattern", input: "name ILIKE", wantErr: true},
+		{name: "dangling IS", input: "active IS", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewFilterParser(allowed)
+			node, err := p.Parse(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Parse(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if err == nil && tt.checkNode != nil {
+				tt.checkNode(t, node)
+			}
+		})
+	}
+}
+
+func mustBinary(t *testing.T, node Node) *BinaryOperatorNode {
+	t.Helper()
+	b, ok := node.(*BinaryOperatorNode)
+	if !ok {
+		t.Fatalf("expected *BinaryOperatorNode, got %T", node)
+	}
+	return b
+}
+
+func checkBoolTest(t *testing.T, node Node, want BooleanTruthValue, isNot bool) *BooleanTestNode {
+	t.Helper()
+	n, ok := node.(*BooleanTestNode)
+	if !ok {
+		t.Fatalf("expected *BooleanTestNode, got %T", node)
+	}
+	if n.Value != want {
+		t.Errorf("Value = %s, want %s", n.Value, want)
+	}
+	if n.IsNot != isNot {
+		t.Errorf("IsNot = %v, want %v", n.IsNot, isNot)
+	}
+	if n.Type() != NodeTypeBooleanTest {
+		t.Errorf("Type() = %s, want BOOLEAN_TEST", n.Type())
+	}
+	if n.Pos().Line == 0 && n.Pos().Column == 0 {
+		// position should be populated from the IS token
+		t.Log("note: boolean test node has zero position")
+	}
+	return n
+}

--- a/filter_tokens.go
+++ b/filter_tokens.go
@@ -38,6 +38,8 @@ const (
 	TokenOperatorNot          TokenType = "NOT"
 	TokenOperatorLike         TokenType = "LIKE"
 	TokenOperatorNotLike      TokenType = "NOT LIKE"
+	TokenOperatorILike        TokenType = "ILIKE"
+	TokenOperatorNotILike     TokenType = "NOT ILIKE"
 	TokenOperatorIn           TokenType = "IN"
 	TokenOperatorIsNotNull    TokenType = "IS NOT NULL"
 	TokenOperatorIsNull       TokenType = "IS NULL"


### PR DESCRIPTION
## Summary

Extends the filter grammar with the **PostgreSQL 18** comparison and pattern-matching predicates most useful for REST API filters, based on the official docs ([Comparison Functions and Operators](https://www.postgresql.org/docs/18/functions-comparison.html), [Pattern Matching](https://www.postgresql.org/docs/18/functions-matching.html)). Also adds a `pkg.go.dev` badge, runnable godoc examples, and raises test coverage to **95.5%**.

## New predicates & operators

| Category | Added |
| --- | --- |
| Case-insensitive LIKE | `ILIKE`, `NOT ILIKE` + operator forms `~~`, `~~*`, `!~~`, `!~~*` |
| Null-safe comparison | `IS DISTINCT FROM`, `IS NOT DISTINCT FROM` (standard `IS` form) |
| Boolean tests | `IS [NOT] TRUE`, `IS [NOT] FALSE`, `IS [NOT] UNKNOWN` |
| Range | `BETWEEN [NOT] SYMMETRIC` (and explicit `ASYMMETRIC`) |
| Null shorthands | `ISNULL`, `NOTNULL` |

Existing operators already supported (`=`, `<>`, `!=`, `<`, `<=`, `>`, `>=`, `LIKE`/`NOT LIKE`, `IN`/`NOT IN`, `BETWEEN`/`NOT BETWEEN`, `IS [NOT] NULL`, `SIMILAR TO`/`NOT SIMILAR TO`, `~ ~* !~ !~*`) are unchanged.

## AST changes (additive)

- **New** `BooleanTestNode{Field, Value, IsNot}` where `Value` is `BooleanTrue`/`BooleanFalse`/`BooleanUnknown`; `NodeTypeBooleanTest`.
- `BetweenNode` gains `IsSymmetric bool`; `String()` appends `SYMMETRIC`.
- `DistinctNode.String()` now renders the canonical `field IS [NOT] DISTINCT FROM value` form (was `field DISTINCT FROM value`). The `Value` field added in the previous PR is now populated via the standard `IS` form too.
- Internals: `parseIsNullOperator` → `parseIsPredicate` (handles `NULL`/`TRUE`/`FALSE`/`UNKNOWN`/`DISTINCT FROM`); `parseLikeOperator` takes the operator token so it serves all four LIKE/ILIKE variants.

No breaking changes for callers that `Parse` and check `err`. All of this lands in the same unreleased **v0.1.0** line as #9, so it's documented in the README's existing migration section (new subsection **"6. New PostgreSQL 18 predicates and operators"**).

## Docs

- Added the `pkg.go.dev` **Go Reference badge**.
- README features/examples updated with every new predicate; note added that patterns are validated as string literals but **not compiled** (compile them yourself if you evaluate the regex).
- Runnable `Example*` functions (Fields/Sort/Filter, PostgreSQL predicates, `errors.As` inspection) — these render on pkg.go.dev.
- Audited that **every** filter example in the README parses.

## Tests

- `filter_pg_predicates_test.go` — table-driven coverage of every new predicate (happy + error paths).
- `filter_nodes_string_test.go` — `String()`/`Type()`/`Pos()` for all nodes incl. negated/CI variants, lexer cursor helpers, literal kinds.
- `filter_errors_test.go` — `QFVFilterError.Error()`, `errors.As` unwrapping, IN/BETWEEN error branches.
- `go vet`, `gofmt`, and `go test -race ./...` all pass; coverage **95.5%**.