### PR TITLE
feat: configurable operators/directions, dotted fields, and docs restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Query Filters Validator (QFV)
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/slashdevops/qfv.svg)](https://pkg.go.dev/github.com/slashdevops/qfv)
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/slashdevops/qfv?style=plastic)
+[![Go Report Card](https://goreportcard.com/badge/github.com/slashdevops/qfv)](https://goreportcard.com/report/github.com/slashdevops/qfv)
+[![license](https://img.shields.io/github/license/slashdevops/qfv.svg)](https://github.com/slashdevops/qfv/blob/main/LICENSE)
+[![Release](https://github.com/slashdevops/qfv/actions/workflows/release.yml/badge.svg)](https://github.com/slashdevops/qfv/actions/workflows/release.yml)
+[![release](https://img.shields.io/github/release/slashdevops/qfv/all.svg)](https://github.com/slashdevops/qfv/releases)
 
 A Go library for parsing and validating the query expressions commonly used in
 REST APIs and database queries — **fields selection**, **filtering**, and

--- a/README.md
+++ b/README.md
@@ -2,330 +2,79 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/slashdevops/qfv.svg)](https://pkg.go.dev/github.com/slashdevops/qfv)
 
-A Go library for parsing and validating query expressions commonly used in REST APIs and database queries. This library provides robust parsing and validation for fields selection, filtering, and sorting operations.
+A Go library for parsing and validating the query expressions commonly used in
+REST APIs and database queries — **fields selection**, **filtering**, and
+**sorting**. Each parser is driven by an allow-list of fields, so only fields you
+permit can appear in a query, helping secure your endpoints against invalid or
+malicious input.
 
-## Overview
-
-QFV (Query Filters Validator) is an Abstract Syntax Tree (AST) parser designed to validate and parse three common types of query expressions:
-
-1. **Fields Selection**: Specify which fields to include in the response
-2. **Filtering**: Apply conditions to filter results
-3. **Sorting**: Define the order of returned results
-
-The library ensures that only allowed fields are used in these expressions, helping to secure your API endpoints against invalid or malicious queries.
-
-## Installation
+## Install
 
 ```bash
 go get github.com/slashdevops/qfv@latest
 ```
 
-## Usage
+Update to the latest release with `go get -u github.com/slashdevops/qfv@latest`.
 
-### Basic Example
+## Quick start
 
 ```go
 package main
 
 import (
-  "fmt"
-  "log"
+    "fmt"
+    "log"
 
-  qfv "github.com/slashdevops/qfv"
+    qfv "github.com/slashdevops/qfv"
 )
 
 func main() {
-  // Define the allowed fields for your API
-  allowedFields := []string{"first_name", "last_name", "email", "created_at", "updated_at"}
+    allowedFields := []string{"first_name", "last_name", "email", "created_at"}
 
-  // Create parsers with the allowed fields
-  sortParser := qfv.NewSortParser(allowedFields)
-  fieldsParser := qfv.NewFieldsParser(allowedFields)
-  filterParser := qfv.NewFilterParser(allowedFields)
+    // Parsers are safe to build once and reuse across goroutines.
+    filterParser := qfv.NewFilterParser(allowedFields)
+    sortParser := qfv.NewSortParser(allowedFields)
+    fieldsParser := qfv.NewFieldsParser(allowedFields)
 
-  // Example inputs from your API
-  sortInput := "first_name ASC,created_at DESC"
-  fieldsInput := "first_name, last_name, email"
-  filterInput := "first_name = 'John' AND last_name = 'Doe'"
+    node, err := filterParser.Parse("first_name = 'John' AND created_at > '2023-01-01'")
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Println(node.String()) // ((first_name = 'John') AND (created_at > '2023-01-01'))
 
-  // Parse and validate the inputs
-  sortNode, err := sortParser.Parse(sortInput)
-  if err != nil {
-    log.Fatalf("Sort validation error: %v", err)
-  }
-
-  fieldsNode, err := fieldsParser.Parse(fieldsInput)
-  if err != nil {
-    log.Fatalf("Fields validation error: %v", err)
-  }
-
-  _, err = filterParser.Parse(filterInput)
-  if err != nil {
-    log.Fatalf("Filter validation error: %v", err)
-  }
-
-  // Use the parsed nodes in your application
-  fmt.Println("Sort fields:")
-  for _, field := range sortNode.Fields {
-    fmt.Printf("  %s %s\n", field.Field, field.Direction)
-  }
-
-  fmt.Println("\nRequested fields:")
-  for _, field := range fieldsNode.Fields {
-    fmt.Printf("  %s\n", field)
-  }
+    if _, err := sortParser.Parse("first_name ASC, created_at DESC"); err != nil {
+        log.Fatal(err)
+    }
+    if _, err := fieldsParser.Parse("first_name, last_name, email"); err != nil {
+        log.Fatal(err)
+    }
 }
 ```
 
 ## Features
 
-### Fields Parser
+- **Three validators** — fields selection, filtering, and sorting, each gated by
+  an allow-list of fields (nested dot-notation like `user.profile.age` supported).
+- **Rich, PostgreSQL-flavored filter grammar** — comparison, logical, `IN`,
+  `BETWEEN [SYMMETRIC]`, `LIKE`/`ILIKE`, `SIMILAR TO`, POSIX regex, `IS NULL`,
+  `IS [NOT] TRUE/FALSE/UNKNOWN`, and `IS [NOT] DISTINCT FROM`.
+- **Configurable** — restrict which operators or sort directions are allowed.
+- **Returns an AST** you can walk or render, with precise, aggregated errors.
+- **Concurrency-safe** parsers.
 
-Parse and validate field selection expressions like:
+## Documentation
 
-```text
-first_name, last_name, email
-```
+Full documentation lives in [`docs/`](docs/README.md):
 
-The parser ensures that:
+- [Getting Started](docs/getting-started.md) — install, update, complete example
+- [Filtering](docs/filtering.md) — the full operator/predicate reference
+- [Configuration](docs/configuration.md) — restrict operators and sort directions
+- [Error Handling](docs/error-handling.md) — inspecting validation failures
+- [Migration Guide](docs/migration.md) — upgrading between versions
 
-- Only allowed fields are requested
-- No empty field names are provided
-- The syntax is valid
+API reference and runnable examples are on
+[pkg.go.dev](https://pkg.go.dev/github.com/slashdevops/qfv).
 
-### Sort Parser
+## License
 
-Parse and validate sort expressions like:
-
-```sql
-first_name ASC, created_at DESC
-```
-
-The parser ensures that:
-
-- Only allowed fields are used for sorting
-- Each field has a valid direction (ASC or DESC)
-- The syntax is valid
-
-### Filter Parser
-
-Parse and validate complex filter expressions like:
-
-```sql
-first_name = 'John' AND last_name = 'Doe' OR email = 'example@example.com'
-```
-
-The filter parser supports a PostgreSQL-flavored grammar (see
-[PostgreSQL 18: Comparison Functions and Operators](https://www.postgresql.org/docs/18/functions-comparison.html)
-and [Pattern Matching](https://www.postgresql.org/docs/18/functions-matching.html)):
-
-- **Logical operators**: `AND`, `OR`, `NOT`
-- **Comparison operators**: `=`, `<>`, `!=`, `<`, `<=`, `>`, `>=`
-- **Range predicates**: `BETWEEN`, `NOT BETWEEN`, `BETWEEN SYMMETRIC`, `NOT BETWEEN SYMMETRIC` (and the explicit `ASYMMETRIC` default)
-- **Set membership**: `IN`, `NOT IN`
-- **Null tests**: `IS NULL`, `IS NOT NULL`, plus the non-standard `ISNULL` / `NOTNULL` shorthands
-- **Boolean tests**: `IS TRUE`, `IS NOT TRUE`, `IS FALSE`, `IS NOT FALSE`, `IS UNKNOWN`, `IS NOT UNKNOWN`
-- **Null-safe comparison**: `IS DISTINCT FROM`, `IS NOT DISTINCT FROM`
-- **Pattern matching**:
-  - `LIKE`, `NOT LIKE` (and operator forms `~~`, `!~~`)
-  - `ILIKE`, `NOT ILIKE` — case-insensitive (and operator forms `~~*`, `!~~*`)
-  - `SIMILAR TO`, `NOT SIMILAR TO` — SQL-standard regex
-- **POSIX regex operators**:
-  - `~`: Case-sensitive regex match
-  - `!~`: Case-sensitive regex non-match
-  - `~*`: Case-insensitive regex match
-  - `!~*`: Case-insensitive regex non-match
-- **Grouping** with parentheses
-- **Literals**: strings (single-quoted, `''` escapes a quote), integers, floats, booleans (`TRUE`/`FALSE`/`YES`/`NO`)
-
-The parser ensures that:
-
-- Only allowed fields are used in filter conditions
-- The syntax is valid
-- The expression forms a valid abstract syntax tree (AST)
-
-## Advanced Filter Examples
-
-```go
-// Simple comparison
-"first_name = 'John'"
-
-// Logical operators
-"first_name = 'John' AND last_name = 'Doe'"
-"first_name = 'John' OR first_name = 'Jane'"
-"NOT (first_name = 'John')"
-
-// Comparison operators
-"age > 30"
-"age >= 30"
-"age < 30"
-"age <= 30"
-"age <> 30"  // Not equal
-"age != 30"  // Not equal (alternative)
-
-// Pattern matching
-"first_name LIKE 'J%'"
-"first_name NOT LIKE 'J%'"
-"first_name ILIKE 'j%'"       // case-insensitive
-"first_name NOT ILIKE 'j%'"
-"name SIMILAR TO 'J%n'"       // SQL standard regex
-"name NOT SIMILAR TO 'J%n'"
-
-// Set membership & ranges
-"status IN ('active', 'pending')"
-"status NOT IN ('archived')"
-"age BETWEEN 20 AND 30"
-"age NOT BETWEEN 20 AND 30"
-"age BETWEEN SYMMETRIC 30 AND 20" // endpoints auto-sorted
-
-// Null / boolean / null-safe tests
-"middle_name IS NULL"
-"middle_name IS NOT NULL"
-"middle_name ISNULL"              // shorthand
-"middle_name NOTNULL"            // shorthand
-"active IS TRUE"
-"active IS NOT FALSE"
-"active IS UNKNOWN"
-"age IS DISTINCT FROM 30"        // null-safe !=
-"age IS NOT DISTINCT FROM 30"    // null-safe =
-"email ~ '^[^@]+@[^@]+\.[^@]+$'" // Case-sensitive regex match
-"email !~ '^[^@]+@[^@]+\.[^@]+$'" // Case-sensitive regex non-match
-"email ~* '(?i)^admin@'" // Case-insensitive regex match (using Go regex flag)
-"email !~* '(?i)^admin@'" // Case-insensitive regex non-match (using Go regex flag)
-
-// Complex expressions
-"(first_name = 'John' OR first_name = 'Jane') AND age > 30"
-"status IN ('active', 'pending') AND created_at > '2023-01-01'"
-```
-
-## Error Handling
-
-The library provides detailed error messages for invalid expressions:
-
-```go
-_, err := filterParser.Parse("unknown_field = 'value'")
-if err != nil {
-    // err contains: "field unknown_field is not allowed"
-}
-
-_, err = filterParser.Parse("first_name = ")
-if err != nil {
-    // err contains syntax error details
-}
-```
-
-The filter parser aggregates every problem it finds in a single pass using
-[`errors.Join`](https://pkg.go.dev/errors#Join), so a returned error may wrap
-several `*QFVFilterError` values. Use `errors.As` to inspect them:
-
-```go
-_, err := filterParser.Parse("unknown = 'x' garbage")
-var fe *qfv.QFVFilterError
-if errors.As(err, &fe) {
-    // fe.Field / fe.Message for the first matching cause
-}
-```
-
-## Breaking Changes & Migration (v0.0.x → v0.1.0)
-
-`v0.1.0` fixes correctness bugs in the filter parser and validator. If you only
-call `Parse` and check the returned `error`, most changes are transparent — the
-parser now rejects inputs it previously accepted by mistake. If you **inspect the
-returned AST**, review the notes below.
-
-### 1. Trailing/incomplete input is now rejected (behavior change)
-
-Previously the parser stopped at the first complete expression and silently
-ignored the rest, so invalid input validated successfully. It now requires the
-**entire** input to be consumed.
-
-| Input | Before `v0.1.0` | `v0.1.0` |
-| --- | --- | --- |
-| `first_name = 'John' garbage` | ✅ accepted | ❌ error |
-| `age > 30 40` | ✅ accepted | ❌ error |
-| `first_name = 'John')` | ✅ accepted | ❌ error |
-| `1 = 1` | ✅ accepted | ❌ error |
-
-**Migration:** none required for valid queries. If you relied on the lenient
-behavior, fix the offending inputs — they were never valid.
-
-### 2. Negated operators now set `IsNot` instead of wrapping in `UnaryOperatorNode` (AST change)
-
-`NOT IN`, `NOT BETWEEN`, `NOT SIMILAR TO`, and `NOT DISTINCT FROM` previously
-produced a `UnaryOperatorNode{Operator: NOT}` wrapping the inner node (whose own
-`IsNot` was always `false`). They now return the operator node directly with
-`IsNot = true`, matching how `RegexMatchNode` already worked. `NOT LIKE` now
-produces a `BinaryOperatorNode` with `Operator = TokenOperatorNotLike` instead of
-a wrapped `TokenOperatorLike`.
-
-```go
-// Before: type-switch had to unwrap the NOT node
-if u, ok := node.(*qfv.UnaryOperatorNode); ok && u.Operator == qfv.TokenOperatorNot {
-    if in, ok := u.X.(*qfv.InNode); ok { /* negated IN */ }
-}
-
-// After: the node carries its own negation
-if in, ok := node.(*qfv.InNode); ok && in.IsNot { /* negated IN */ }
-```
-
-The `IsNot` fields on `InNode`, `BetweenNode`, `SimilarToNode`, and `DistinctNode`
-are now meaningful, and `Type()` returns the corresponding `NodeTypeNotIn`,
-`NodeTypeNotBetween`, `NodeTypeNotSimilarTo`, or `NodeTypeNotDistinct`. The
-`String()` methods now render the `NOT`/`IS NOT` form correctly.
-
-> Note: a standalone leading `NOT` (e.g. `NOT (age > 30)`) is unchanged — it
-> still produces a `UnaryOperatorNode`.
-
-### 3. `DistinctNode` gained a `Value` field (AST change)
-
-`DISTINCT FROM <value>` previously discarded the compared value. `DistinctNode`
-now has a `Value Node` field holding it (`nil` when absent).
-
-```go
-type DistinctNode struct {
-    Field Node
-    Value Node // NEW: the value in "field IS [NOT] DISTINCT FROM value"
-    IsNot bool
-}
-```
-
-### 4. `Parse` returns a joined error, not a single formatted string (error shape change)
-
-`FilterParser.Parse` now returns `errors.Join(...)` of `*QFVFilterError` values
-rather than one `*QFVFilterError` whose message embedded the others. Use
-`errors.As`/`errors.Is` to inspect causes (see [Error Handling](#error-handling)).
-Code that only checked `err != nil` is unaffected.
-
-### 5. `FilterParser` is now safe for concurrent use
-
-A single `*FilterParser` (like `*SortParser` and `*FieldsParser`) can now be
-created once and shared across goroutines; per-request state is no longer stored
-on the parser. No API change — this simply removes a data race.
-
-### 6. New PostgreSQL 18 predicates and operators (additive)
-
-The filter grammar gained the following predicates, aligned with
-[PostgreSQL 18](https://www.postgresql.org/docs/18/functions-comparison.html).
-These are additive — existing queries keep parsing — with the AST notes below:
-
-| Predicate / operator | AST node |
-| --- | --- |
-| `ILIKE`, `NOT ILIKE` (and `~~`, `~~*`, `!~~`, `!~~*`) | `BinaryOperatorNode` with `Operator` `ILIKE` / `NOT ILIKE` (or `LIKE` / `NOT LIKE` for the plain forms) |
-| `IS [NOT] TRUE`, `IS [NOT] FALSE`, `IS [NOT] UNKNOWN` | new `BooleanTestNode{Field, Value, IsNot}` (`Value` is `BooleanTrue`/`BooleanFalse`/`BooleanUnknown`) |
-| `IS [NOT] DISTINCT FROM <value>` | `DistinctNode` (now reachable via the standard `IS` form) |
-| `BETWEEN [NOT] SYMMETRIC` (and explicit `ASYMMETRIC`) | `BetweenNode` gained `IsSymmetric bool` |
-| `ISNULL`, `NOTNULL` shorthands | `IsNullNode` (with `IsNot=true` for `NOTNULL`) |
-
-Two node changes accompany these:
-
-- `DistinctNode` gained a `Value Node` field (the right-hand side of
-  `IS [NOT] DISTINCT FROM`), and its `String()` now renders the canonical
-  `field IS [NOT] DISTINCT FROM value` form (previously `field DISTINCT FROM value`).
-- `BetweenNode` gained an `IsSymmetric bool` field; `String()` appends
-  `SYMMETRIC` when set.
-
-> Note on `ILIKE`/regex operators: the parser validates that the right-hand side
-> is a **string literal**, but it does not compile the pattern. If you evaluate
-> the pattern with Go's `regexp`, validate/compile it yourself. Single-quoted
-> string literals treat backslashes literally (only `''` is an escape), so a
-> regex like `'^\d+$'` reaches you with the backslash intact.
+See the repository for license details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# QFV Documentation
+
+Reference documentation for the **Query Filters Validator** (`github.com/slashdevops/qfv`).
+
+| Guide | What it covers |
+| --- | --- |
+| [Getting Started](getting-started.md) | Install, update, and a complete runnable example of the three parsers |
+| [Filtering](filtering.md) | The full filter grammar — every operator/predicate, dotted fields, and worked examples |
+| [Configuration](configuration.md) | Restricting which operators and sort directions are allowed |
+| [Error Handling](error-handling.md) | Error shapes and how to inspect validation failures |
+| [Migration Guide](migration.md) | Breaking changes and how to upgrade between versions |
+
+The full API reference is on
+[pkg.go.dev](https://pkg.go.dev/github.com/slashdevops/qfv), including runnable
+examples.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,90 @@
+# Configuration
+
+By default the filter parser accepts every operator and the sort parser accepts
+both `ASC` and `DESC`. You can narrow either with functional options at
+construction time.
+
+## Restricting filter operators
+
+Pass `WithAllowedOperators` and/or `WithAllowedOperatorGroups` to
+`NewFilterParser`. Anything outside the allow-list is reported as a validation
+error (`operator "LIKE" is not allowed`). When neither option is used, all
+operators are allowed.
+
+```go
+p := qfv.NewFilterParser(fields,
+    qfv.WithAllowedOperatorGroups(qfv.GroupComparison, qfv.GroupLogical),
+    qfv.WithAllowedOperators(qfv.OpIn),
+)
+
+p.Parse("age >= 18 AND status IN ('active')") // ok
+p.Parse("name LIKE '%x%'")                     // error: operator "LIKE" is not allowed
+```
+
+The two options are **additive** — groups expand to their operators and merge
+with any individually listed operators.
+
+### Operators
+
+| Operator | Matches |
+| --- | --- |
+| `OpAnd`, `OpOr`, `OpNot` | `AND`, `OR`, standalone `NOT` |
+| `OpEqual`, `OpNotEqual` | `=`; `<>` and `!=` |
+| `OpLessThan`, `OpLessThanOrEqual` | `<`, `<=` |
+| `OpGreaterThan`, `OpGreaterThanOrEqual` | `>`, `>=` |
+| `OpLike` | `LIKE`, `NOT LIKE`, `~~`, `!~~` |
+| `OpILike` | `ILIKE`, `NOT ILIKE`, `~~*`, `!~~*` |
+| `OpSimilarTo` | `SIMILAR TO`, `NOT SIMILAR TO` |
+| `OpRegexMatch` | `~`, `~*`, `!~`, `!~*` |
+| `OpIn` | `IN`, `NOT IN` |
+| `OpBetween` | `BETWEEN`, `NOT BETWEEN`, `SYMMETRIC` |
+| `OpIsNull` | `IS [NOT] NULL`, `ISNULL`, `NOTNULL` |
+| `OpBooleanTest` | `IS [NOT] TRUE/FALSE/UNKNOWN` |
+| `OpIsDistinctFrom` | `IS [NOT] DISTINCT FROM` |
+
+`qfv.AllOperators()` returns the complete list.
+
+### Groups
+
+| Group | Operators |
+| --- | --- |
+| `GroupLogical` | `AND`, `OR`, `NOT` |
+| `GroupComparison` | `=`, `<>`, `<`, `<=`, `>`, `>=` |
+| `GroupPattern` | `LIKE`, `ILIKE`, `SIMILAR TO`, regex |
+| `GroupMembership` | `IN` |
+| `GroupRange` | `BETWEEN` |
+| `GroupNull` | `IS NULL` |
+| `GroupBoolean` | `IS TRUE/FALSE/UNKNOWN` |
+| `GroupDistinct` | `IS DISTINCT FROM` |
+
+`OperatorGroup.Operators()` returns the operators a group expands to.
+
+### Negation semantics
+
+A negated **predicate** is governed by its base operator, not by `OpNot`:
+
+- `NOT IN`, `NOT LIKE`, `NOT BETWEEN`, `NOT SIMILAR TO`, `IS NOT DISTINCT FROM`
+  are allowed whenever `OpIn` / `OpLike` / `OpBetween` / `OpSimilarTo` /
+  `OpIsDistinctFrom` (respectively) are allowed.
+- `OpNot` governs only the **standalone** logical `NOT`, e.g. `NOT (age > 30)`.
+
+So allowing `OpEqual` but not `OpNot` accepts `a = 1` but rejects `NOT (a = 1)`.
+
+## Restricting sort directions
+
+Pass `WithAllowedDirections` to `NewSortParser` to forbid a direction:
+
+```go
+p := qfv.NewSortParser(fields, qfv.WithAllowedDirections(qfv.SortAsc))
+
+p.Parse("first_name ASC")  // ok
+p.Parse("first_name DESC") // error: sort direction "DESC" is not allowed
+```
+
+When the option is not used, both `ASC` and `DESC` are allowed.
+
+## Nested field names
+
+Field allow-lists accept dotted paths in every parser (`fields`, `sort`, and
+`filter`), so `user.profile.age` works out of the box — see
+[Filtering › Nested field names](filtering.md#nested-dot-notation-field-names).

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,51 @@
+# Error Handling
+
+Each parser returns a typed error describing what failed.
+
+```go
+_, err := filterParser.Parse("unknown_field = 'value'")
+if err != nil {
+    // "field 'unknown_field' is not allowed"
+}
+
+_, err = filterParser.Parse("first_name = ")
+if err != nil {
+    // syntax error details
+}
+```
+
+## Error types
+
+- `*QFVFilterError` — filter parser failures (has `Field` and `Message`)
+- `*QFVSortError` — sort parser failures
+- `*QFVFieldsError` — fields parser failures
+
+## Aggregated filter errors
+
+`FilterParser.Parse` collects **every** problem in a single pass and returns
+them joined with [`errors.Join`](https://pkg.go.dev/errors#Join). The returned
+error may therefore wrap several `*QFVFilterError` values. Use `errors.As` to
+extract the first matching cause, or `errors.Is` for sentinel checks:
+
+```go
+_, err := filterParser.Parse("unknown = 'x' garbage")
+
+var fe *qfv.QFVFilterError
+if errors.As(err, &fe) {
+    // fe.Field   -> "unknown"
+    // fe.Message -> "field not allowed"
+}
+```
+
+Because the parser continues after the first error, a single call can report,
+for example, both a disallowed field and a disallowed operator at once.
+
+## What counts as invalid
+
+The filter parser rejects, among others:
+
+- unknown fields (not in the allow-list),
+- disallowed operators (see [Configuration](configuration.md)),
+- trailing or incomplete input — the **entire** string must form one expression
+  (`first_name = 'John' garbage` is an error),
+- unterminated strings, unbalanced parentheses, and illegal characters.

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -1,0 +1,134 @@
+# Filtering
+
+The filter parser validates complex boolean expressions and returns an AST. It
+implements a PostgreSQL-flavored grammar; see the PostgreSQL 18 references for
+[Comparison Functions and Operators](https://www.postgresql.org/docs/18/functions-comparison.html)
+and [Pattern Matching](https://www.postgresql.org/docs/18/functions-matching.html).
+
+```go
+filterParser := qfv.NewFilterParser(allowedFields)
+node, err := filterParser.Parse("first_name = 'John' AND age >= 18")
+```
+
+The parser guarantees that:
+
+- only allow-listed fields are used,
+- the syntax is valid and the **entire** input is consumed,
+- the result is a well-formed AST.
+
+## Supported operators
+
+| Category | Operators |
+| --- | --- |
+| Logical | `AND`, `OR`, `NOT` |
+| Comparison | `=`, `<>`, `!=`, `<`, `<=`, `>`, `>=` |
+| Range | `BETWEEN`, `NOT BETWEEN`, `BETWEEN SYMMETRIC`, `NOT BETWEEN SYMMETRIC` (explicit `ASYMMETRIC` is the default) |
+| Set membership | `IN`, `NOT IN` |
+| Null tests | `IS NULL`, `IS NOT NULL`, and the non-standard `ISNULL` / `NOTNULL` shorthands |
+| Boolean tests | `IS TRUE`, `IS NOT TRUE`, `IS FALSE`, `IS NOT FALSE`, `IS UNKNOWN`, `IS NOT UNKNOWN` |
+| Null-safe comparison | `IS DISTINCT FROM`, `IS NOT DISTINCT FROM` |
+| Pattern matching | `LIKE`, `NOT LIKE` (`~~`, `!~~`); `ILIKE`, `NOT ILIKE` (`~~*`, `!~~*`); `SIMILAR TO`, `NOT SIMILAR TO` |
+| POSIX regex | `~` (match), `!~` (non-match), `~*` (case-insensitive match), `!~*` (case-insensitive non-match) |
+| Grouping | `( ... )` |
+
+**Literals**: single-quoted strings (`''` escapes a quote), integers, floats,
+and booleans (`TRUE`/`FALSE`/`YES`/`NO`).
+
+## Nested (dot-notation) field names
+
+Field names may contain dots, so you can allow-list and filter on nested paths:
+
+```go
+p := qfv.NewFilterParser([]string{"user.profile.age", "user.name"})
+node, _ := p.Parse("user.profile.age >= 18 AND user.name = 'John'")
+// ((user.profile.age >= 18) AND (user.name = 'John'))
+```
+
+A dot is only valid **inside** an identifier, so numeric literals such as `3.14`
+are unaffected. Unknown dotted fields are rejected by the allow-list like any
+other field.
+
+## Worked examples
+
+```go
+// Simple comparison
+"first_name = 'John'"
+
+// Logical operators
+"first_name = 'John' AND last_name = 'Doe'"
+"first_name = 'John' OR first_name = 'Jane'"
+"NOT (first_name = 'John')"
+
+// Comparison operators
+"age > 30"
+"age <> 30"   // not equal
+"age != 30"   // not equal (alias)
+
+// Pattern matching
+"first_name LIKE 'J%'"
+"first_name NOT LIKE 'J%'"
+"first_name ILIKE 'j%'"            // case-insensitive
+"first_name NOT ILIKE 'j%'"
+"name SIMILAR TO 'J%n'"            // SQL-standard regex
+"name NOT SIMILAR TO 'J%n'"
+
+// Set membership & ranges
+"status IN ('active', 'pending')"
+"status NOT IN ('archived')"
+"age BETWEEN 20 AND 30"
+"age NOT BETWEEN 20 AND 30"
+"age BETWEEN SYMMETRIC 30 AND 20"  // endpoints auto-sorted
+
+// Null / boolean / null-safe tests
+"middle_name IS NULL"
+"middle_name IS NOT NULL"
+"middle_name ISNULL"               // shorthand
+"middle_name NOTNULL"              // shorthand
+"active IS TRUE"
+"active IS NOT FALSE"
+"active IS UNKNOWN"
+"age IS DISTINCT FROM 30"          // null-safe !=
+"age IS NOT DISTINCT FROM 30"      // null-safe =
+
+// POSIX regex
+"email ~ '^[^@]+@[^@]+\.[^@]+$'"   // case-sensitive match
+"email !~ '^[^@]+@[^@]+\.[^@]+$'"  // case-sensitive non-match
+"email ~* '(?i)^admin@'"           // case-insensitive match
+"email !~* '(?i)^admin@'"          // case-insensitive non-match
+
+// Complex expressions
+"(first_name = 'John' OR first_name = 'Jane') AND age > 30"
+"status IN ('active', 'pending') AND created_at > '2023-01-01'"
+```
+
+## AST nodes
+
+`Parse` returns a `qfv.Node`. Common concrete types:
+
+| Node | Produced by |
+| --- | --- |
+| `BinaryOperatorNode` | comparisons, `AND`/`OR`, `LIKE`/`ILIKE` |
+| `UnaryOperatorNode` | a standalone leading `NOT` |
+| `GroupNode` | parenthesized expressions |
+| `InNode` | `IN` / `NOT IN` (`IsNot`) |
+| `BetweenNode` | `BETWEEN` (`IsNot`, `IsSymmetric`) |
+| `IsNullNode` | `IS [NOT] NULL`, `ISNULL`/`NOTNULL` (`IsNot`) |
+| `BooleanTestNode` | `IS [NOT] TRUE/FALSE/UNKNOWN` (`Value`, `IsNot`) |
+| `DistinctNode` | `IS [NOT] DISTINCT FROM` (`Value`, `IsNot`) |
+| `SimilarToNode` | `SIMILAR TO` / `NOT SIMILAR TO` (`IsNot`) |
+| `RegexMatchNode` | `~ ~* !~ !~*` (`IsNot`, `IsCaseInsensitive`) |
+| `IdentifierNode` / `LiteralNode` | field names / literal values |
+
+Every node implements `Type() NodeType`, `String() string`, and
+`Pos() scanner.Position`.
+
+> **Patterns are not compiled.** For `LIKE`/`ILIKE`/`SIMILAR TO`/regex operators
+> the parser only checks that the right-hand side is a string literal. If you
+> evaluate the pattern with Go's `regexp`, compile/validate it yourself.
+> Single-quoted string literals keep backslashes verbatim (only `''` is an
+> escape), so `'^\d+$'` reaches you with the backslash intact.
+
+## See also
+
+- [Configuration](configuration.md) — allow only a subset of these operators
+- [Error Handling](error-handling.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,98 @@
+# Getting Started
+
+## Install
+
+```bash
+go get github.com/slashdevops/qfv@latest
+```
+
+## Update
+
+```bash
+go get -u github.com/slashdevops/qfv@latest
+go mod tidy
+```
+
+To pin or move to a specific version:
+
+```bash
+go get github.com/slashdevops/qfv@v0.1.0
+```
+
+## Overview
+
+QFV (Query Filters Validator) is an Abstract Syntax Tree (AST) parser that
+validates and parses three common kinds of query expression:
+
+1. **Fields selection** — which fields to include in the response
+2. **Filtering** — conditions used to filter results
+3. **Sorting** — the order of returned results
+
+Every parser is built from an **allow-list of fields**, so only fields you
+explicitly permit can appear in a query. This is the primary defense against
+invalid or malicious input reaching your database.
+
+All three parsers are **safe for concurrent use** — build them once and share
+them across goroutines.
+
+## Complete example
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    qfv "github.com/slashdevops/qfv"
+)
+
+func main() {
+    // Fields your API is willing to expose.
+    allowedFields := []string{"first_name", "last_name", "email", "created_at", "updated_at"}
+
+    // Build the parsers once; they are safe to reuse concurrently.
+    sortParser := qfv.NewSortParser(allowedFields)
+    fieldsParser := qfv.NewFieldsParser(allowedFields)
+    filterParser := qfv.NewFilterParser(allowedFields)
+
+    // Example inputs (typically query-string parameters).
+    sortInput := "first_name ASC, created_at DESC"
+    fieldsInput := "first_name, last_name, email"
+    filterInput := "first_name = 'John' AND last_name = 'Doe'"
+
+    sortNode, err := sortParser.Parse(sortInput)
+    if err != nil {
+        log.Fatalf("sort validation error: %v", err)
+    }
+
+    fieldsNode, err := fieldsParser.Parse(fieldsInput)
+    if err != nil {
+        log.Fatalf("fields validation error: %v", err)
+    }
+
+    filterNode, err := filterParser.Parse(filterInput)
+    if err != nil {
+        log.Fatalf("filter validation error: %v", err)
+    }
+
+    fmt.Println("Sort fields:")
+    for _, f := range sortNode.Fields {
+        fmt.Printf("  %s %s\n", f.Field, f.Direction)
+    }
+
+    fmt.Println("Requested fields:")
+    for _, f := range fieldsNode.Fields {
+        fmt.Printf("  %s\n", f)
+    }
+
+    // The filter parser returns an AST you can walk or render.
+    fmt.Println("Filter AST:", filterNode.String())
+}
+```
+
+## Next steps
+
+- [Filtering](filtering.md) — the full set of operators and predicates
+- [Configuration](configuration.md) — restrict operators and sort directions
+- [Error Handling](error-handling.md) — inspecting validation failures

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,109 @@
+# Migration Guide
+
+## v0.0.x → v0.1.0
+
+`v0.1.0` fixes correctness bugs in the filter parser, adds the PostgreSQL 18
+predicate set, and introduces configurable operators/directions and dotted
+field names. If you only call `Parse` and check the returned `error`, most
+changes are transparent — the parser now rejects inputs it previously accepted
+by mistake. If you **inspect the returned AST**, review the notes below.
+
+### 1. Trailing/incomplete input is now rejected (behavior change)
+
+Previously the parser stopped at the first complete expression and silently
+ignored the rest, so invalid input validated successfully. It now requires the
+**entire** input to be consumed.
+
+| Input | Before | `v0.1.0` |
+| --- | --- | --- |
+| `first_name = 'John' garbage` | ✅ accepted | ❌ error |
+| `age > 30 40` | ✅ accepted | ❌ error |
+| `first_name = 'John')` | ✅ accepted | ❌ error |
+| `1 = 1` | ✅ accepted | ❌ error |
+
+**Migration:** none required for valid queries. If you relied on the lenient
+behavior, fix the offending inputs — they were never valid.
+
+### 2. Negated operators set `IsNot` instead of wrapping in `UnaryOperatorNode` (AST change)
+
+`NOT IN`, `NOT BETWEEN`, `NOT SIMILAR TO`, and `NOT DISTINCT FROM` previously
+produced a `UnaryOperatorNode{Operator: NOT}` wrapping the inner node (whose own
+`IsNot` was always `false`). They now return the operator node directly with
+`IsNot = true`, matching how `RegexMatchNode` already worked. `NOT LIKE` now
+produces a `BinaryOperatorNode` with `Operator = TokenOperatorNotLike`.
+
+```go
+// Before: type-switch had to unwrap the NOT node
+if u, ok := node.(*qfv.UnaryOperatorNode); ok && u.Operator == qfv.TokenOperatorNot {
+    if in, ok := u.X.(*qfv.InNode); ok { /* negated IN */ }
+}
+
+// After: the node carries its own negation
+if in, ok := node.(*qfv.InNode); ok && in.IsNot { /* negated IN */ }
+```
+
+The `IsNot` fields on `InNode`, `BetweenNode`, `SimilarToNode`, and
+`DistinctNode` are now meaningful, `Type()` returns the corresponding
+`NodeTypeNotIn` / `NodeTypeNotBetween` / `NodeTypeNotSimilarTo` /
+`NodeTypeNotDistinct`, and `String()` renders the `NOT`/`IS NOT` form.
+
+> A standalone leading `NOT` (e.g. `NOT (age > 30)`) is unchanged — it still
+> produces a `UnaryOperatorNode`.
+
+### 3. `DistinctNode` gained a `Value` field (AST change)
+
+`IS [NOT] DISTINCT FROM <value>` previously discarded the compared value.
+`DistinctNode` now holds it:
+
+```go
+type DistinctNode struct {
+    Field Node
+    Value Node // NEW: the right-hand side value (nil when absent)
+    IsNot bool
+}
+```
+
+Its `String()` now renders the canonical `field IS [NOT] DISTINCT FROM value`.
+
+### 4. `Parse` returns a joined error (error shape change)
+
+`FilterParser.Parse` returns `errors.Join(...)` of `*QFVFilterError` values
+rather than a single formatted string. Use `errors.As` / `errors.Is` to inspect
+causes — see [Error Handling](error-handling.md). Code that only checks
+`err != nil` is unaffected.
+
+### 5. `FilterParser` is safe for concurrent use
+
+A single `*FilterParser` (like `*SortParser` and `*FieldsParser`) can now be
+created once and shared across goroutines; per-request state is no longer stored
+on the parser. No API change — this removes a data race.
+
+### 6. New PostgreSQL 18 predicates (additive)
+
+The grammar gained the following; existing queries keep parsing:
+
+| Predicate / operator | AST |
+| --- | --- |
+| `ILIKE`, `NOT ILIKE` (and `~~`, `~~*`, `!~~`, `!~~*`) | `BinaryOperatorNode` with `ILIKE`/`NOT ILIKE` (or `LIKE`/`NOT LIKE`) |
+| `IS [NOT] TRUE/FALSE/UNKNOWN` | new `BooleanTestNode{Field, Value, IsNot}` |
+| `IS [NOT] DISTINCT FROM <value>` | `DistinctNode` via the standard `IS` form |
+| `BETWEEN [NOT] SYMMETRIC` (explicit `ASYMMETRIC`) | `BetweenNode.IsSymmetric` |
+| `ISNULL`, `NOTNULL` shorthands | `IsNullNode` (`IsNot=true` for `NOTNULL`) |
+
+### 7. Constructors accept functional options (source-compatible)
+
+`NewFilterParser(fields)` and `NewSortParser(fields)` gained variadic options:
+
+```go
+func NewFilterParser(allowedFields []string, opts ...FilterOption) *FilterParser
+func NewSortParser(allowedFields []string, opts ...SortOption) *SortParser
+```
+
+Existing calls compile unchanged. See [Configuration](configuration.md) for
+`WithAllowedOperators`, `WithAllowedOperatorGroups`, and `WithAllowedDirections`.
+
+### 8. Dotted field names (additive)
+
+Field names may now contain dots (`user.profile.age`) in all three parsers.
+Numeric literals such as `3.14` are unaffected. See
+[Filtering › Nested field names](filtering.md#nested-dot-notation-field-names).

--- a/example_doc_test.go
+++ b/example_doc_test.go
@@ -85,3 +85,51 @@ func ExampleFilterParser_errorInspection() {
 	// Output:
 	// field "secret" rejected: field not allowed
 }
+
+// ExampleWithAllowedOperatorGroups restricts the grammar to a subset of
+// operators. Anything outside the allow-list is rejected at parse time.
+func ExampleWithAllowedOperatorGroups() {
+	parser := qfv.NewFilterParser(allowed,
+		qfv.WithAllowedOperatorGroups(qfv.GroupComparison, qfv.GroupLogical),
+		qfv.WithAllowedOperators(qfv.OpIn),
+	)
+
+	if _, err := parser.Parse("age >= 18 AND email IN ('a@x.com', 'b@x.com')"); err == nil {
+		fmt.Println("comparison + IN: allowed")
+	}
+	if _, err := parser.Parse("email LIKE '%@x.com'"); err != nil {
+		fmt.Println("LIKE:", err)
+	}
+	// Output:
+	// comparison + IN: allowed
+	// LIKE: error: operator "LIKE" is not allowed
+}
+
+// ExampleWithAllowedDirections forbids DESC sorting.
+func ExampleWithAllowedDirections() {
+	parser := qfv.NewSortParser(allowed, qfv.WithAllowedDirections(qfv.SortAsc))
+
+	if _, err := parser.Parse("first_name ASC"); err == nil {
+		fmt.Println("ASC: allowed")
+	}
+	if _, err := parser.Parse("first_name DESC"); err != nil {
+		fmt.Println("DESC:", err)
+	}
+	// Output:
+	// ASC: allowed
+	// DESC: error on field 'first_name': sort direction "DESC" is not allowed
+}
+
+// ExampleFilterParser_dottedFields shows nested dot-notation field names.
+func ExampleFilterParser_dottedFields() {
+	parser := qfv.NewFilterParser([]string{"user.profile.age", "user.name"})
+
+	node, err := parser.Parse("user.profile.age >= 18 AND user.name = 'John'")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(node.String())
+	// Output:
+	// ((user.profile.age >= 18) AND (user.name = 'John'))
+}

--- a/filter_lexer.go
+++ b/filter_lexer.go
@@ -3,6 +3,7 @@ package qfv
 import (
 	"strings"
 	"text/scanner"
+	"unicode"
 )
 
 // Lexer breaks the input string into tokens
@@ -22,6 +23,12 @@ func NewLexer(input string) *Lexer {
 	s.Mode = scanner.ScanIdents | scanner.ScanFloats | scanner.ScanStrings
 	s.Whitespace = 1<<'\t' | 1<<'\n' | 1<<'\r' | 1<<' ' // Define whitespace chars
 	s.Error = func(*scanner.Scanner, string) {}         // Suppress default errors
+	// Allow dotted identifiers (e.g. "q.v.last_name") to be scanned as a single
+	// token. A dot is permitted only in interior positions, so a leading digit
+	// still starts a number and "3.14" is scanned as a float, not an identifier.
+	s.IsIdentRune = func(ch rune, i int) bool {
+		return ch == '_' || unicode.IsLetter(ch) || (i > 0 && (unicode.IsDigit(ch) || ch == '.'))
+	}
 
 	l := &Lexer{s: s, input: input, pos: -1} // Start at -1, first Next moves to 0
 	l.inputLen = len(input)

--- a/filter_options.go
+++ b/filter_options.go
@@ -1,0 +1,137 @@
+package qfv
+
+// Operator identifies a filter verb that can be allowed or disallowed on a
+// FilterParser. Values are human-readable and used verbatim in error messages.
+type Operator string
+
+const (
+	// Logical operators.
+	OpAnd Operator = "AND" // a AND b
+	OpOr  Operator = "OR"  // a OR b
+	OpNot Operator = "NOT" // NOT (a) — the standalone unary NOT only
+
+	// Comparison operators.
+	OpEqual              Operator = "="  // = (also drives the != / <> aliases)
+	OpNotEqual           Operator = "<>" // <> and !=
+	OpLessThan           Operator = "<"
+	OpLessThanOrEqual    Operator = "<="
+	OpGreaterThan        Operator = ">"
+	OpGreaterThanOrEqual Operator = ">="
+
+	// Pattern-matching operators. Each verb covers its negated form too, e.g.
+	// OpLike governs both LIKE and NOT LIKE; OpRegexMatch governs ~ ~* !~ !~*.
+	OpLike       Operator = "LIKE"       // LIKE, NOT LIKE, ~~, !~~
+	OpILike      Operator = "ILIKE"      // ILIKE, NOT ILIKE, ~~*, !~~*
+	OpSimilarTo  Operator = "SIMILAR TO" // SIMILAR TO, NOT SIMILAR TO
+	OpRegexMatch Operator = "~"          // ~, ~*, !~, !~*
+
+	// Set membership and range. OpIn covers NOT IN; OpBetween covers
+	// NOT BETWEEN and the SYMMETRIC/ASYMMETRIC modifiers.
+	OpIn      Operator = "IN"
+	OpBetween Operator = "BETWEEN"
+
+	// IS-family predicates. OpIsNull covers IS NULL, IS NOT NULL and the
+	// ISNULL/NOTNULL shorthands; OpBooleanTest covers IS [NOT] TRUE/FALSE/UNKNOWN;
+	// OpIsDistinctFrom covers IS [NOT] DISTINCT FROM.
+	OpIsNull         Operator = "IS NULL"
+	OpBooleanTest    Operator = "IS BOOLEAN"
+	OpIsDistinctFrom Operator = "IS DISTINCT FROM"
+)
+
+// OperatorGroup is a convenience preset that expands to a set of Operators.
+type OperatorGroup string
+
+const (
+	GroupLogical    OperatorGroup = "LOGICAL"    // AND, OR, NOT
+	GroupComparison OperatorGroup = "COMPARISON" // = <> < <= > >=
+	GroupPattern    OperatorGroup = "PATTERN"    // LIKE, ILIKE, SIMILAR TO, regex
+	GroupMembership OperatorGroup = "MEMBERSHIP" // IN
+	GroupRange      OperatorGroup = "RANGE"      // BETWEEN
+	GroupNull       OperatorGroup = "NULL"       // IS NULL / ISNULL
+	GroupBoolean    OperatorGroup = "BOOLEAN"    // IS TRUE/FALSE/UNKNOWN
+	GroupDistinct   OperatorGroup = "DISTINCT"   // IS DISTINCT FROM
+)
+
+var operatorGroups = map[OperatorGroup][]Operator{
+	GroupLogical:    {OpAnd, OpOr, OpNot},
+	GroupComparison: {OpEqual, OpNotEqual, OpLessThan, OpLessThanOrEqual, OpGreaterThan, OpGreaterThanOrEqual},
+	GroupPattern:    {OpLike, OpILike, OpSimilarTo, OpRegexMatch},
+	GroupMembership: {OpIn},
+	GroupRange:      {OpBetween},
+	GroupNull:       {OpIsNull},
+	GroupBoolean:    {OpBooleanTest},
+	GroupDistinct:   {OpIsDistinctFrom},
+}
+
+// Operators returns the operators a group expands to. The returned slice is a
+// copy and safe to modify.
+func (g OperatorGroup) Operators() []Operator {
+	ops := operatorGroups[g]
+	out := make([]Operator, len(ops))
+	copy(out, ops)
+	return out
+}
+
+// AllOperators returns every operator the filter parser understands. This is the
+// implicit default when no WithAllowedOperators/WithAllowedOperatorGroups option
+// is supplied.
+func AllOperators() []Operator {
+	return []Operator{
+		OpAnd, OpOr, OpNot,
+		OpEqual, OpNotEqual, OpLessThan, OpLessThanOrEqual, OpGreaterThan, OpGreaterThanOrEqual,
+		OpLike, OpILike, OpSimilarTo, OpRegexMatch,
+		OpIn, OpBetween, OpIsNull, OpBooleanTest, OpIsDistinctFrom,
+	}
+}
+
+// FilterOption configures a FilterParser at construction time.
+type FilterOption func(*FilterParser)
+
+// WithAllowedOperators restricts the filter parser to the given operators.
+// It is additive with WithAllowedOperatorGroups. When neither option is used,
+// all operators are allowed.
+func WithAllowedOperators(ops ...Operator) FilterOption {
+	return func(p *FilterParser) {
+		if p.allowedOps == nil {
+			p.allowedOps = make(map[Operator]struct{})
+		}
+		for _, o := range ops {
+			p.allowedOps[o] = struct{}{}
+		}
+	}
+}
+
+// WithAllowedOperatorGroups restricts the filter parser to the operators in the
+// given groups. It is additive with WithAllowedOperators. When neither option is
+// used, all operators are allowed.
+func WithAllowedOperatorGroups(groups ...OperatorGroup) FilterOption {
+	return func(p *FilterParser) {
+		if p.allowedOps == nil {
+			p.allowedOps = make(map[Operator]struct{})
+		}
+		for _, g := range groups {
+			for _, o := range operatorGroups[g] {
+				p.allowedOps[o] = struct{}{}
+			}
+		}
+	}
+}
+
+// comparisonOperator maps a comparison token to its Operator.
+func comparisonOperator(tok TokenType) Operator {
+	switch tok {
+	case TokenOperatorEqual:
+		return OpEqual
+	case TokenOperatorNotEqual, TokenOperatorNotEqualAlias:
+		return OpNotEqual
+	case TokenOperatorLessThan:
+		return OpLessThan
+	case TokenOperatorLessThanOrEqualTo:
+		return OpLessThanOrEqual
+	case TokenOperatorGreaterThan:
+		return OpGreaterThan
+	case TokenOperatorGreaterThanOrEqualTo:
+		return OpGreaterThanOrEqual
+	}
+	return ""
+}

--- a/filter_options_test.go
+++ b/filter_options_test.go
@@ -1,0 +1,162 @@
+package qfv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFilterParser_OperatorGating(t *testing.T) {
+	fields := []string{"a", "b", "name", "age"}
+
+	t.Run("default allows everything", func(t *testing.T) {
+		p := NewFilterParser(fields)
+		for _, in := range []string{
+			"a = 1", "a LIKE 'x'", "a ILIKE 'x'", "a IN (1, 2)", "a BETWEEN 1 AND 2",
+			"a IS NULL", "a IS TRUE", "a IS DISTINCT FROM 1", "a ~ 'x'", "a SIMILAR TO 'x'",
+			"NOT (a = 1)", "a = 1 AND b = 2", "a = 1 OR b = 2",
+		} {
+			if _, err := p.Parse(in); err != nil {
+				t.Errorf("default parser rejected %q: %v", in, err)
+			}
+		}
+	})
+
+	t.Run("restrict to comparison + logical", func(t *testing.T) {
+		p := NewFilterParser(fields, WithAllowedOperatorGroups(GroupComparison, GroupLogical))
+		allowed := []string{"a = 1", "a <> 1", "a > 1 AND b < 2", "NOT (a = 1)", "a = 1 OR b = 2"}
+		for _, in := range allowed {
+			if _, err := p.Parse(in); err != nil {
+				t.Errorf("expected %q allowed: %v", in, err)
+			}
+		}
+		blocked := map[string]string{
+			"a LIKE 'x'":           `"LIKE"`,
+			"a IN (1, 2)":          `"IN"`,
+			"a IS NULL":            `"IS NULL"`,
+			"a IS TRUE":            `"IS BOOLEAN"`,
+			"a IS DISTINCT FROM 1": `"IS DISTINCT FROM"`,
+			"a ~ 'x'":              `"~"`,
+			"a BETWEEN 1 AND 2":    `"BETWEEN"`,
+		}
+		for in, want := range blocked {
+			_, err := p.Parse(in)
+			if err == nil {
+				t.Errorf("expected %q blocked", in)
+				continue
+			}
+			if !strings.Contains(err.Error(), "is not allowed") || !strings.Contains(err.Error(), want) {
+				t.Errorf("Parse(%q) error = %v, want mention of %s not allowed", in, err, want)
+			}
+		}
+	})
+
+	t.Run("individual operators are additive with groups", func(t *testing.T) {
+		p := NewFilterParser(fields,
+			WithAllowedOperatorGroups(GroupComparison),
+			WithAllowedOperators(OpIn, OpAnd))
+		if _, err := p.Parse("a = 1 AND a IN (1, 2)"); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if _, err := p.Parse("a LIKE 'x'"); err == nil {
+			t.Error("LIKE should still be blocked")
+		}
+	})
+
+	t.Run("negated forms follow the base operator", func(t *testing.T) {
+		p := NewFilterParser(fields, WithAllowedOperators(OpIn, OpLike, OpBetween))
+		for _, in := range []string{"a NOT IN (1, 2)", "a NOT LIKE 'x'", "a NOT BETWEEN 1 AND 2"} {
+			if _, err := p.Parse(in); err != nil {
+				t.Errorf("expected %q allowed via base operator: %v", in, err)
+			}
+		}
+	})
+
+	t.Run("standalone NOT gated by OpNot", func(t *testing.T) {
+		// OpEqual allowed but OpNot not: the leading NOT should be rejected.
+		p := NewFilterParser(fields, WithAllowedOperators(OpEqual))
+		if _, err := p.Parse("NOT (a = 1)"); err == nil {
+			t.Error("expected leading NOT to be blocked without OpNot")
+		}
+	})
+}
+
+func TestOperatorGroups_Coverage(t *testing.T) {
+	// Every operator returned by AllOperators must belong to exactly one group,
+	// guarding against a new operator being added without a group.
+	inGroup := map[Operator]int{}
+	for _, g := range []OperatorGroup{
+		GroupLogical, GroupComparison, GroupPattern, GroupMembership,
+		GroupRange, GroupNull, GroupBoolean, GroupDistinct,
+	} {
+		for _, op := range g.Operators() {
+			inGroup[op]++
+		}
+	}
+	for _, op := range AllOperators() {
+		if inGroup[op] != 1 {
+			t.Errorf("operator %q appears in %d groups, want exactly 1", op, inGroup[op])
+		}
+	}
+}
+
+func TestSortParser_DirectionGating(t *testing.T) {
+	fields := []string{"name", "created_at"}
+
+	t.Run("default allows ASC and DESC", func(t *testing.T) {
+		p := NewSortParser(fields)
+		if _, err := p.Parse("name ASC, created_at DESC"); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("restrict to ASC only", func(t *testing.T) {
+		p := NewSortParser(fields, WithAllowedDirections(SortAsc))
+		if _, err := p.Parse("name ASC"); err != nil {
+			t.Errorf("ASC should be allowed: %v", err)
+		}
+		_, err := p.Parse("name DESC")
+		if err == nil {
+			t.Fatal("DESC should be blocked")
+		}
+		if !strings.Contains(err.Error(), "not allowed") {
+			t.Errorf("error = %v, want 'not allowed'", err)
+		}
+	})
+}
+
+func TestFilterParser_DottedIdentifiers(t *testing.T) {
+	p := NewFilterParser([]string{"q.v.last_name", "user.profile.age", "name"})
+
+	tests := []struct {
+		in      string
+		wantStr string
+	}{
+		{"q.v.last_name = 'Doe'", "(q.v.last_name = 'Doe')"},
+		{"user.profile.age >= 18 AND name = 'x'", "((user.profile.age >= 18) AND (name = 'x'))"},
+		{"q.v.last_name IN ('a', 'b')", "q.v.last_name IN ('a', 'b')"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			node, err := p.Parse(tt.in)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", tt.in, err)
+			}
+			if got := node.String(); got != tt.wantStr {
+				t.Errorf("String() = %q, want %q", got, tt.wantStr)
+			}
+		})
+	}
+
+	t.Run("unknown dotted field rejected", func(t *testing.T) {
+		if _, err := p.Parse("q.v.secret = 'x'"); err == nil {
+			t.Error("expected unknown dotted field to be rejected")
+		}
+	})
+
+	t.Run("numeric literals still parse", func(t *testing.T) {
+		fp := NewFilterParser([]string{"score", "age"})
+		if _, err := fp.Parse("score = 3.14 AND age = 42"); err != nil {
+			t.Errorf("numeric literals broke: %v", err)
+		}
+	})
+}

--- a/filter_parser.go
+++ b/filter_parser.go
@@ -29,25 +29,36 @@ func (e *QFVFilterError) Error() string {
 // state required to parse one expression lives in a per-call filterParseState.
 type FilterParser struct {
 	allowedFields map[string]struct{}
+	// allowedOps is the set of permitted operators. A nil map means every
+	// operator is allowed (the default).
+	allowedOps map[Operator]struct{}
 }
 
-// NewFilterParser creates a new parser with the allowed fields
-func NewFilterParser(allowedFields []string) *FilterParser {
+// NewFilterParser creates a new parser with the allowed fields. By default every
+// operator is permitted; pass WithAllowedOperators / WithAllowedOperatorGroups to
+// restrict the grammar to a subset.
+func NewFilterParser(allowedFields []string, opts ...FilterOption) *FilterParser {
 	filterFields := make(map[string]struct{}, len(allowedFields))
 
 	for _, f := range allowedFields {
 		filterFields[f] = struct{}{}
 	}
 
-	return &FilterParser{
+	p := &FilterParser{
 		allowedFields: filterFields,
 	}
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p
 }
 
 // filterParseState holds the mutable state for a single Parse call. Keeping it
 // out of FilterParser is what makes FilterParser safe for concurrent reuse.
 type filterParseState struct {
 	allowedFields map[string]struct{}
+	allowedOps    map[Operator]struct{}
 	lexer         *Lexer
 	currentToken  Token
 	errors        []error
@@ -57,6 +68,7 @@ type filterParseState struct {
 func (p *FilterParser) Parse(input string) (Node, error) {
 	st := &filterParseState{
 		allowedFields: p.allowedFields,
+		allowedOps:    p.allowedOps,
 		lexer:         NewLexer(input),
 	}
 	st.lexer.Parse()
@@ -111,6 +123,18 @@ func (p *filterParseState) addError(err error) {
 	p.errors = append(p.errors, err)
 }
 
+// requireOp records a validation error when op is not in the allow-list. A nil
+// allow-list means every operator is permitted. Parsing continues either way so
+// that all problems are collected in a single pass.
+func (p *filterParseState) requireOp(op Operator) {
+	if p.allowedOps == nil {
+		return
+	}
+	if _, ok := p.allowedOps[op]; !ok {
+		p.addError(&QFVFilterError{Message: fmt.Sprintf("operator %q is not allowed", op)})
+	}
+}
+
 // parseExpression parses an expression
 func (p *filterParseState) parseExpression() Node {
 	return p.parseLogicalOr()
@@ -123,6 +147,7 @@ func (p *filterParseState) parseLogicalOr() Node {
 	for p.currentToken.Type == TokenOperatorOr {
 		pos := p.currentToken.Pos
 		operator := p.currentToken.Type
+		p.requireOp(OpOr)
 		p.nextToken()
 		right := p.parseLogicalAnd()
 		left = &BinaryOperatorNode{
@@ -143,6 +168,7 @@ func (p *filterParseState) parseLogicalAnd() Node {
 	for p.currentToken.Type == TokenOperatorAnd {
 		pos := p.currentToken.Pos
 		operator := p.currentToken.Type
+		p.requireOp(OpAnd)
 		p.nextToken()
 		right := p.parseComparison()
 		left = &BinaryOperatorNode{
@@ -161,6 +187,7 @@ func (p *filterParseState) parseComparison() Node {
 	// Check for NOT operator
 	if p.currentToken.Type == TokenOperatorNot {
 		pos := p.currentToken.Pos
+		p.requireOp(OpNot)
 		p.nextToken()
 		expr := p.parseComparison()
 		return &UnaryOperatorNode{
@@ -203,10 +230,12 @@ func (p *filterParseState) parseComparison() Node {
 			switch strings.ToUpper(p.currentToken.Value) {
 			case "ISNULL":
 				pos := p.currentToken.Pos
+				p.requireOp(OpIsNull)
 				p.nextToken()
 				return &IsNullNode{baseNode: baseNode{pos: pos}, Field: field, IsNot: false}
 			case "NOTNULL":
 				pos := p.currentToken.Pos
+				p.requireOp(OpIsNull)
 				p.nextToken()
 				return &IsNullNode{baseNode: baseNode{pos: pos}, Field: field, IsNot: true}
 			}
@@ -217,35 +246,45 @@ func (p *filterParseState) parseComparison() Node {
 		case TokenOperatorEqual, TokenOperatorNotEqual, TokenOperatorNotEqualAlias,
 			TokenOperatorLessThan, TokenOperatorLessThanOrEqualTo,
 			TokenOperatorGreaterThan, TokenOperatorGreaterThanOrEqualTo:
+			p.requireOp(comparisonOperator(p.currentToken.Type))
 			return p.parseComparisonOperator(field)
 		case TokenOperatorLike:
+			p.requireOp(OpLike)
 			p.nextToken() // Consume LIKE (or ~~)
 			return p.parseLikeOperator(field, TokenOperatorLike)
 		case TokenOperatorILike:
+			p.requireOp(OpILike)
 			p.nextToken() // Consume ILIKE (or ~~*)
 			return p.parseLikeOperator(field, TokenOperatorILike)
 		case TokenOperatorNotLike:
+			p.requireOp(OpLike)
 			p.nextToken() // Consume !~~ (operator form of NOT LIKE)
 			return p.parseLikeOperator(field, TokenOperatorNotLike)
 		case TokenOperatorNotILike:
+			p.requireOp(OpILike)
 			p.nextToken() // Consume !~~* (operator form of NOT ILIKE)
 			return p.parseLikeOperator(field, TokenOperatorNotILike)
 		case TokenOperatorIn:
+			p.requireOp(OpIn)
 			p.nextToken() // Consume IN
 			return p.parseInOperator(field, false)
 		case TokenOperatorBetween:
+			p.requireOp(OpBetween)
 			p.nextToken() // Consume BETWEEN
 			return p.parseBetweenOperator(field, false)
 		case TokenOperatorIsNull:
 			p.nextToken() // Consume IS
 			return p.parseIsPredicate(field)
 		case TokenOperatorDistinct:
+			p.requireOp(OpIsDistinctFrom)
 			p.nextToken() // Consume DISTINCT
 			return p.parseDistinctOperator(field, false)
 		case TokenOperatorSimilarTo:
+			p.requireOp(OpSimilarTo)
 			p.nextToken() // Consume SIMILAR
 			return p.parseSimilarToOperator(field, false)
 		case TokenOperatorRegexMatchCS, TokenOperatorNotRegexMatchCS, TokenOperatorRegexMatchCI, TokenOperatorNotRegexMatchCI:
+			p.requireOp(OpRegexMatch)
 			opToken := p.currentToken
 			p.nextToken() // Consume regex operator
 			patternNode := p.parsePrimary()
@@ -275,21 +314,27 @@ func (p *filterParseState) parseComparison() Node {
 
 			switch p.currentToken.Type {
 			case TokenOperatorIn:
+				p.requireOp(OpIn)
 				p.nextToken() // Consume IN
 				return p.parseInOperator(field, true)
 			case TokenOperatorBetween:
+				p.requireOp(OpBetween)
 				p.nextToken() // Consume BETWEEN
 				return p.parseBetweenOperator(field, true)
 			case TokenOperatorLike:
+				p.requireOp(OpLike)
 				p.nextToken() // Consume LIKE
 				return p.parseLikeOperator(field, TokenOperatorNotLike)
 			case TokenOperatorILike:
+				p.requireOp(OpILike)
 				p.nextToken() // Consume ILIKE
 				return p.parseLikeOperator(field, TokenOperatorNotILike)
 			case TokenOperatorSimilarTo:
+				p.requireOp(OpSimilarTo)
 				p.nextToken() // Consume SIMILAR
 				return p.parseSimilarToOperator(field, true)
 			case TokenOperatorDistinct:
+				p.requireOp(OpIsDistinctFrom)
 				p.nextToken() // Consume DISTINCT
 				return p.parseDistinctOperator(field, true)
 			default:
@@ -447,11 +492,13 @@ func (p *filterParseState) parseIsPredicate(field Node) Node {
 	switch {
 	case p.currentToken.Type == TokenOperatorDistinct:
 		// IS [NOT] DISTINCT FROM <value>
+		p.requireOp(OpIsDistinctFrom)
 		p.nextToken() // Consume DISTINCT
 		return p.parseDistinctOperator(field, isNot)
 
 	case p.currentToken.Type == TokenBoolean:
 		// IS [NOT] TRUE | FALSE (TRUE/YES and FALSE/NO are lexed as booleans)
+		p.requireOp(OpBooleanTest)
 		truth := BooleanTrue
 		if v := strings.ToUpper(p.currentToken.Value); v == "FALSE" || v == "NO" {
 			truth = BooleanFalse
@@ -460,10 +507,12 @@ func (p *filterParseState) parseIsPredicate(field Node) Node {
 		return &BooleanTestNode{baseNode: baseNode{pos: pos}, Field: field, Value: truth, IsNot: isNot}
 
 	case p.currentToken.Type == TokenIdentifier && strings.ToUpper(p.currentToken.Value) == "NULL":
+		p.requireOp(OpIsNull)
 		p.nextToken() // Consume NULL
 		return &IsNullNode{baseNode: baseNode{pos: pos}, Field: field, IsNot: isNot}
 
 	case p.currentToken.Type == TokenIdentifier && strings.ToUpper(p.currentToken.Value) == "UNKNOWN":
+		p.requireOp(OpBooleanTest)
 		p.nextToken() // Consume UNKNOWN
 		return &BooleanTestNode{baseNode: baseNode{pos: pos}, Field: field, Value: BooleanUnknown, IsNot: isNot}
 	}

--- a/sort_parser.go
+++ b/sort_parser.go
@@ -52,19 +52,54 @@ func (n SortNode) Type() NodeType {
 // SortParser parses the query parameter for sorting
 type SortParser struct {
 	allowedFields map[string]struct{}
+	// allowedDirections is the set of permitted sort directions. A nil map means
+	// both ASC and DESC are allowed (the default).
+	allowedDirections map[SortDirection]struct{}
 }
 
-// NewSortParser creates a new parser with the allowed fields for sorting
-func NewSortParser(allowedFields []string) *SortParser {
+// SortOption configures a SortParser at construction time.
+type SortOption func(*SortParser)
+
+// WithAllowedDirections restricts sorting to the given directions. When the
+// option is not used, both ASC and DESC are allowed.
+func WithAllowedDirections(dirs ...SortDirection) SortOption {
+	return func(p *SortParser) {
+		if p.allowedDirections == nil {
+			p.allowedDirections = make(map[SortDirection]struct{})
+		}
+		for _, d := range dirs {
+			p.allowedDirections[d] = struct{}{}
+		}
+	}
+}
+
+// NewSortParser creates a new parser with the allowed fields for sorting. By
+// default both ASC and DESC are permitted; pass WithAllowedDirections to
+// restrict them.
+func NewSortParser(allowedFields []string, opts ...SortOption) *SortParser {
 	sortFields := make(map[string]struct{}, len(allowedFields))
 
 	for _, f := range allowedFields {
 		sortFields[f] = struct{}{}
 	}
 
-	return &SortParser{
+	p := &SortParser{
 		allowedFields: sortFields,
 	}
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	return p
+}
+
+// directionAllowed reports whether dir is permitted. A nil allow-list permits all.
+func (p *SortParser) directionAllowed(dir SortDirection) bool {
+	if p.allowedDirections == nil {
+		return true
+	}
+	_, ok := p.allowedDirections[dir]
+	return ok
 }
 
 // Parse parses the sort parameter
@@ -112,6 +147,10 @@ func (p *SortParser) Parse(input string) (SortNode, error) {
 			default:
 				return SortNode{}, &QFVSortError{Field: fieldName, Message: "invalid sort direction"}
 			}
+		}
+
+		if !p.directionAllowed(direction) {
+			return SortNode{}, &QFVSortError{Field: fieldName, Message: fmt.Sprintf("sort direction %q is not allowed", direction)}
 		}
 
 		fields = append(fields, SortFieldNode{


### PR DESCRIPTION
## Summary

Three related additions, all backward compatible, plus a documentation restructure.

### 1. Configurable filter operators (opt-in)

Callers can restrict which operators a `FilterParser` accepts; the default (no option) still allows everything.

```go
p := qfv.NewFilterParser(fields,
    qfv.WithAllowedOperatorGroups(qfv.GroupComparison, qfv.GroupLogical),
    qfv.WithAllowedOperators(qfv.OpIn),
)
p.Parse("age >= 18 AND status IN ('active')") // ok
p.Parse("name LIKE '%x%'")                     // error: operator "LIKE" is not allowed
```

- New `Operator` enum (per-verb) + `OperatorGroup` presets (`GroupComparison`, `GroupPattern`, `GroupLogical`, …), both **additive**.
- Helpers `AllOperators()` and `OperatorGroup.Operators()`.
- Disallowed verbs are reported through the existing single-pass error aggregation.
- **Negation semantics:** negated predicates (`NOT IN`, `NOT LIKE`, `IS NOT DISTINCT FROM`, …) are governed by their base operator; `OpNot` governs only the standalone leading `NOT (…)`.

### 2. Configurable sort directions (opt-in)

```go
p := qfv.NewSortParser(fields, qfv.WithAllowedDirections(qfv.SortAsc))
p.Parse("name DESC") // error: sort direction "DESC" is not allowed
```

### 3. Nested dot-notation field names

`FilterParser` now accepts dotted identifiers via `scanner.IsIdentRune`:

```go
p := qfv.NewFilterParser([]string{"user.profile.age", "user.name"})
p.Parse("user.profile.age >= 18 AND user.name = 'John'")
```

A dot is valid only **inside** an identifier, so numeric literals (`3.14`) are unaffected. `FieldsParser`/`SortParser` already matched dotted names (plain string comparison); this brings `FilterParser` in line. Unknown dotted fields are rejected by the allow-list as usual.

**Constructors stay source-compatible** — `NewFilterParser(fields)` / `NewSortParser(fields)` gained variadic options, so existing calls compile unchanged.

## Documentation restructure

- Detailed guides moved into [`docs/`](docs/README.md): getting-started, filtering, configuration, error-handling, migration.
- Top-level `README.md` slimmed to essentials — install/update, a quick-start, a short feature list, and links into `docs/`.
- New godoc `Example*` functions for the new options and dotted fields.

## Tests

- Operator gating (groups + individual, additive, negation), group-coverage invariant, sort-direction gating, dotted-identifier parsing, numeric-literal regression.
- `go vet`, `gofmt`, `go test -race ./...` all pass; coverage **96.6%**.

All of this targets the same unreleased **v0.1.0** line; the migration guide (`docs/migration.md`) documents it as additive items 7–8.