### PR TITLE
chore: add open-source project files (license, security, CI)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# These are supported funding model platforms
+github: [christiangda]
+liberapay: christiangda
+patreon: christiangda
+custom: ["https://paypal.me/slashdevops"]

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,13 @@
+name: CodeQL config
+# queries:
+#   - name: Run custom queries
+#     uses: ./queries
+#   # Run all extra query suites, both because we want to
+#   # and because it'll act as extra testing. This is why
+#   # we include both even though one is a superset of the
+#   # other, because we're testing the parsing logic and
+#   # that the suites exist in the codeql bundle.
+#   - uses: security-extended
+#   - uses: security-and-quality
+paths-ignore:
+  - example

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,44 @@
+# Development Guidelines
+
+This document contains the critical information about working with the project codebase.
+Follows these guidelines precisely to ensure consistency and maintainability of the code.
+
+## Stack
+
+- Language: Go (Go 1.22+)
+- Framework: Go standard library
+- Testing: Go's built-in testing package
+- Dependency Management: Go modules
+- Version Control: Git
+- Documentation: go doc
+- Code Review: Pull requests on GitHub
+- CI/CD: GitHub Actions
+
+## Project Structure
+
+Since this is a library build in native go, the files are mostly organized following the standard Go project layout with some additional folders for specific functionalities.
+
+- Library files are located in the root directory.
+- example/ contains example code demonstrating how to use the library.
+- docs/ contains additional documentation.
+- .github/ contains GitHub-specific files such as workflows for CI/CD.
+- .gitignore specifies files and directories to be ignored by Git.
+- .vscode/ contains Visual Studio Code configuration files.
+- LICENSE is the license file for the project.
+- README.md provides an overview of the project, installation instructions, usage examples, and other relevant information.
+- go.mod and go.sum manage the project's dependencies.
+- \*.go files contain the main source code of the library.
+- \*\_test.go files contain the test cases for the library.
+
+## Code Style
+
+- Follow Go's idiomatic style defined in
+  - #fetch https://google.github.io/styleguide/go/guide
+  - #fetch https://google.github.io/styleguide/go/decisions
+  - #fetch https://google.github.io/styleguide/go/best-practices
+  - #fetch https://golang.org/doc/effective_go.html
+- Use meaningful names for variables, functions, and packages.
+- Keep functions small and focused on a single task.
+- Use comments to explain complex logic or decisions.
+- Use dependency injection for services and repositories to facilitate testing and maintainability.
+- don't use `interface{}` instead use `any` for better readability.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,101 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "10 12 * * 3"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: go
+            build-mode: autobuild
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # Add any setup steps before running the `github/codeql-action/init` action.
+      # This includes steps like installing compilers or runtimes (`actions/setup-node`
+      # or others). This is typically only required for manual builds.
+      # - name: Setup runtime (example)
+      #   uses: actions/setup-example@v1
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
+
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,73 @@
+version: "2"
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - errcheck
+    - ineffassign
+    - staticcheck
+    - unused
+
+  # Disable specific linter
+  # https://golangci-lint.run/usage/linters/#disabled-by-default
+  disable:
+    # Enable presets.
+    # https://golangci-lint.run/usage/linters
+    # Default: []
+    - govet
+    - godot
+    - wsl
+    - testpackage
+    - whitespace
+    - tagalign
+    - nosprintfhostport
+    - nlreturn
+    - nestif
+    - mnd
+    - misspell
+    - lll
+    - godox
+    - funlen
+    - gochecknoinits
+    - depguard
+    - goconst
+    - dupword
+    - cyclop
+    - gocognit
+    - maintidx
+    - gocyclo
+    - dupl
+
+  settings:
+    errcheck:
+      # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
+      # Such cases aren't reported by default.
+      # Default: false
+      check-type-assertions: false
+      # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`.
+      # Such cases aren't reported by default.
+      # Default: false
+      check-blank: false
+      # To disable the errcheck built-in exclude list.
+      # See `-excludeonly` option in https://github.com/kisielk/errcheck#excluding-functions for details.
+      # Default: false
+      disable-default-exclusions: true
+      # List of functions to exclude from checking, where each entry is a single function to exclude.
+      # See https://github.com/kisielk/errcheck#excluding-functions for details.
+      exclude-functions:
+        - (*os.File).Close
+        - (io.Closer).Close
+        - io/ioutil.ReadFile
+        - io.Copy(*bytes.Buffer)
+        - io.Copy(os.Stdout)
+        - (io.Writer).Write
+        - (*bufio.Writer).Write
+        - (*encoding/json.Encoder).Encode
+        - os.Setenv
+        - os.Unsetenv
+        - fmt.Printf
+        - fmt.Print
+        - fmt.Println
+        - fmt.Fprint
+        - fmt.Fprintf
+        - (*strings.Builder).WriteString

--- a/DEVELOPMENT_GUIDELINES.md
+++ b/DEVELOPMENT_GUIDELINES.md
@@ -1,0 +1,44 @@
+# Development Guidelines
+
+This document contains the critical information about working with the project codebase.
+Follows these guidelines precisely to ensure consistency and maintainability of the code.
+
+## Stack
+
+- Language: Go (Go 1.22+)
+- Framework: Go standard library
+- Testing: Go's built-in testing package
+- Dependency Management: Go modules
+- Version Control: Git
+- Documentation: go doc
+- Code Review: Pull requests on GitHub
+- CI/CD: GitHub Actions
+
+## Project Structure
+
+Since this is a library build in native go, the files are mostly organized following the standard Go project layout with some additional folders for specific functionalities.
+
+- Library files are located in the root directory.
+- example/ contains example code demonstrating how to use the library.
+- docs/ contains additional documentation.
+- .github/ contains GitHub-specific files such as workflows for CI/CD.
+- .gitignore specifies files and directories to be ignored by Git.
+- .vscode/ contains Visual Studio Code configuration files.
+- LICENSE is the license file for the project.
+- README.md provides an overview of the project, installation instructions, usage examples, and other relevant information.
+- go.mod and go.sum manage the project's dependencies.
+- \*.go files contain the main source code of the library.
+- \*\_test.go files contain the test cases for the library.
+
+## Code Style
+
+- Follow Go's idiomatic style defined in
+  - #fetch https://google.github.io/styleguide/go/guide
+  - #fetch https://google.github.io/styleguide/go/decisions
+  - #fetch https://google.github.io/styleguide/go/best-practices
+  - #fetch https://golang.org/doc/effective_go.html
+- Use meaningful names for variables, functions, and packages.
+- Keep functions small and focused on a single task.
+- Use comments to explain complex logic or decisions.
+- Use dependency injection for services and repositories to facilitate testing and maintainability.
+- don't use `interface{}` instead use `any` for better readability.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/slashdevops/qfv.svg)](https://pkg.go.dev/github.com/slashdevops/qfv)
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/slashdevops/qfv?style=plastic)
-[![Go Report Card](https://goreportcard.com/badge/github.com/slashdevops/qfv)](https://goreportcard.com/report/github.com/slashdevops/qfv)
 [![license](https://img.shields.io/github/license/slashdevops/qfv.svg)](https://github.com/slashdevops/qfv/blob/main/LICENSE)
 [![Release](https://github.com/slashdevops/qfv/actions/workflows/release.yml/badge.svg)](https://github.com/slashdevops/qfv/actions/workflows/release.yml)
 [![release](https://img.shields.io/github/release/slashdevops/qfv/all.svg)](https://github.com/slashdevops/qfv/releases)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+This project is using [Github CodeQL](https://codeql.github.com/) tool to scan the code vulnerabilities and you can see the report in the pipeline
+[![CodeQL Advanced](https://github.com/slashdevops/qfv/actions/workflows/codeql.yml/badge.svg)](https://github.com/slashdevops/qfv/actions/workflows/codeql.yml)
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.0.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Use the [Project Issues --> Vulnerability](https://github.com/slashdevops/qfv/issues/new/choose) to report it


### PR DESCRIPTION
Rounds out the repository with the standard files expected of a public open-source Go library, mirroring the setup used in [slashdevops/httpx](https://github.com/slashdevops/httpx).

## What's added

- **LICENSE** — Apache-2.0.
- **SECURITY.md** — security policy pointing at CodeQL scanning and how to report vulnerabilities.
- **.github/workflows/codeql.yml** + **.github/codeql/codeql-config.yml** — CodeQL Advanced code scanning (Go + Actions) on push/PR to `main` and a weekly schedule.
- **.golangci.yaml** — golangci-lint v2 configuration.
- **DEVELOPMENT_GUIDELINES.md** + **.github/copilot-instructions.md** — contributor/development guidelines.
- **.github/FUNDING.yml** — funding links.
- **.github/dependabot.yml** — weekly `gomod` and `github-actions` dependency updates.

## README

- Removed the **Go Report Card** badge (the service has been retired). The remaining badges (Go Reference, go.mod version, license, Release) are unchanged.

All existing files were left untouched; `go build` and `go vet` pass.